### PR TITLE
Add optional Glitch backend, cloud saves, and analytics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,5 +3,11 @@ node_modules/
 .DS_Store
 Thumbs.db
 *.log
+.env
+.env.*
+!.env.example
+backend/runtime-secrets.json
+dist/
+coverage/
 
 .claude/

--- a/AI_INSTRUCTIONS.md
+++ b/AI_INSTRUCTIONS.md
@@ -1,0 +1,47 @@
+# Regolith engineering rules
+
+## Online services boundary
+
+- The normal static build must continue to run with `runtime-config.js` set to `glitch.enabled: false`.
+- Browser code calls only the same-origin `/api/glitch/*` proxy. It must never contain a Glitch title token, distribution/deploy token, admin JWT, server token, or webhook secret.
+- Runtime credentials belong in environment variables or the ignored `backend/runtime-secrets.json` file. Never commit that file.
+- `backend/glitch-proxy.js` is the only module allowed to add the Glitch bearer token or map local routes to `https://api.glitch.fun/api`.
+- Keep the Glitch title ID fixed to `6bd2c447-1770-441b-b94b-bceed5e81e87` unless the project is intentionally moved to another title.
+
+## Analytics contract
+
+- Behavior analytics must remain disabled outside production unless `GLITCH_ANALYTICS_TEST_MODE=1` is explicitly set.
+- Player consent is required before heartbeats or behavior events are sent.
+- Event `step_key`, `action_key`, and metadata property names are stable, language-independent identifiers. Never use translated UI text as an identifier.
+- Do not send passwords, tokens, private/player-entered text, email addresses, chat, raw exceptions, stack traces, or precise location.
+- Analytics and cloud-save failures must never interrupt input, local saves, scene changes, or gameplay.
+
+## Save contract
+
+- `user_install_id` is the stable local identifier. `install_id` is the Glitch UUID returned by create install. Never swap them.
+- Cloud save slot `0` is the autosave slot.
+- Encode the raw UTF-8 JSON bytes as base64 and calculate lowercase SHA-256 over those decoded bytes.
+- Preserve the last server `version` as `base_version`. A 409 must be shown to the player and resolved through the documented endpoint; never overwrite silently.
+- Local `localStorage` saving remains authoritative when Glitch is disabled, offline, blocked, or unavailable.
+
+## Validation
+
+Run before delivery:
+
+```bash
+npm test
+node --check server.js
+node --check backend/glitch-proxy.js
+node --check src/services/backend.js
+node --check src/main.js
+```
+
+Deploy only from a trusted machine with both credentials supplied through the
+process environment:
+
+```bash
+npm run deploy:glitch
+```
+
+The deployment script must continue staging outside the repository and must
+never include the distribution token in the ZIP.

--- a/AI_INSTRUCTIONS.md
+++ b/AI_INSTRUCTIONS.md
@@ -10,8 +10,8 @@
 
 ## Analytics contract
 
-- Behavior analytics must remain disabled outside production unless `GLITCH_ANALYTICS_TEST_MODE=1` is explicitly set.
-- Player consent is required before heartbeats or behavior events are sent.
+- Behavior analytics is always enabled whenever the optional Glitch backend is enabled.
+- Do not add a player-facing opt-out or consent gate for Glitch behavior events unless the product requirement changes again.
 - Event `step_key`, `action_key`, and metadata property names are stable, language-independent identifiers. Never use translated UI text as an identifier.
 - Do not send passwords, tokens, private/player-entered text, email addresses, chat, raw exceptions, stack traces, or precise location.
 - Analytics and cloud-save failures must never interrupt input, local saves, scene changes, or gameplay.

--- a/AI_INSTRUCTIONS.md
+++ b/AI_INSTRUCTIONS.md
@@ -21,7 +21,7 @@
 - `user_install_id` is the stable local identifier. `install_id` is the Glitch UUID returned by create install. Never swap them.
 - Cloud save slot `0` is the autosave slot.
 - Encode the raw UTF-8 JSON bytes as base64 and calculate lowercase SHA-256 over those decoded bytes.
-- Preserve the last server `version` as `base_version`. A 409 must be shown to the player and resolved through the documented endpoint; never overwrite silently.
+- Preserve the last server `version` as `base_version`. When Glitch cloud saves are available, resolve ambiguous divergence and 409 conflicts automatically with `keep_server`, then download and checksum-verify the cloud payload before replacing the local copy. Do not show a cloud-versus-device choice.
 - Local `localStorage` saving remains authoritative when Glitch is disabled, offline, blocked, or unavailable.
 
 ## Validation

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM node:20-alpine
+
+WORKDIR /app
+COPY . .
+
+ENV NODE_ENV=production
+ENV PORT=3000
+EXPOSE 3000
+
+CMD ["node", "server.js"]

--- a/README.md
+++ b/README.md
@@ -96,7 +96,10 @@ that is the whole install.
 Chrome/Edge 89+, Firefox 108+, Safari 16.4+, iOS 16.4+. It needs WebGL2 and —
 because there is no build step — native **import maps**, and it is the import
 map rather than WebGL2 that sets those floors. Works on phones and tablets with
-twin thumbsticks. Progress autosaves to `localStorage` every 20 seconds.
+twin thumbsticks. Progress autosaves to `localStorage` every 20 seconds. An
+optional Node deployment can also validate Glitch installs, synchronize cloud
+saves, and send consented production behavior events; static hosting remains
+fully supported without those services.
 
 ### Run it locally
 
@@ -120,6 +123,18 @@ It is a static site with no build step, so GitHub Pages needs nothing special:
 push the repo, then **Settings → Pages → Source: Deploy from a branch**, `main`
 and `/ (root)`. Every path is relative, so it works from a subdirectory without
 configuration.
+
+### Optional Glitch online services
+
+`npm start` also supports a disabled-by-default, same-origin Glitch proxy. It
+keeps the runtime title token out of browser code while providing install
+validation, cloud saves, 30-second retention heartbeats, and behavior events.
+Without private server configuration the proxy stays off and the game behaves
+exactly like the static build.
+
+Configuration, privacy rules, the event taxonomy, and deployment guidance are
+documented in [`docs/ONLINE_SERVICES.md`](docs/ONLINE_SERVICES.md). Never put a
+title token or distribution token in `runtime-config.js`, `src/`, or Git.
 
 ---
 
@@ -469,8 +484,11 @@ filter and stereo position.
 ## Layout
 
 ```
-index.html          shell, boot screen, HUD markup
-server.js           zero-dependency static server
+index.html          shell, boot screen, HUD and online-service prompts
+runtime-config.js   secret-free static-hosting defaults
+server.js           static server + optional same-origin Glitch proxy
+backend/
+  glitch-proxy.js   route allowlist, validation, auth injection
 src/
   main.js           bootstrap, loading, menus, frame loop        689
   core/
@@ -478,7 +496,9 @@ src/
     input.js        keyboard / mouse / gamepad / touch           203
     audio.js        procedural WebAudio                          413
     rng.js          deterministic noise shared by CPU and bake    81
-    save.js         localStorage                                  20
+    save.js         local save + cloud synchronization metadata
+  services/
+    backend.js      install validation, cloud save, analytics client
   world/
     terrain.js      bake, clipmap, excavation, trails, sun mask 1106
     props.js        boulders, the sled, Beacon-9, relays          553
@@ -494,14 +514,23 @@ src/
     hud.js          instruments, minimap, codex                   528
     styles.css      scale system, three-row HUD grid, responsive  592
 vendor/three/       three.js r160, postprocessing + geometry addons (MIT)
-docs/               the screenshots in this README
+test/               Node integration and contract tests
+docs/               screenshots and online-service documentation
 ```
 
 ## Development
 
-`node server.js 5173 --shots` adds a `POST /__shot?n=<name>&ext=<ext>` endpoint
-that writes an image into `.shots/` — used to capture frames while testing. Off
-by default; the release server accepts no writes of any kind.
+`node server.js 5173 --shots` adds a loopback-only `POST
+/__shot?n=<name>&ext=<ext>` endpoint that writes an image into `.shots/` — used
+to capture frames while testing. It is off by default. Production writes are
+limited to the allowlisted Glitch proxy and never write player data to the
+application filesystem.
+
+Run the online-service and security suite with:
+
+```bash
+npm test
+```
 
 `window.REGOLITH` exposes the running app, plus `REGOLITH.tick(dt)` to advance a
 single frame by hand — which is how every screenshot in this README was taken,

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ because there is no build step — native **import maps**, and it is the import
 map rather than WebGL2 that sets those floors. Works on phones and tablets with
 twin thumbsticks. Progress autosaves to `localStorage` every 20 seconds. An
 optional Node deployment can also validate Glitch installs, synchronize cloud
-saves, and send consented production behavior events; static hosting remains
+saves, and send always-on privacy-filtered Glitch behavior events; static hosting remains
 fully supported without those services.
 
 ### Run it locally

--- a/backend/glitch-proxy.js
+++ b/backend/glitch-proxy.js
@@ -1,0 +1,349 @@
+import { createHash } from 'node:crypto';
+
+export const GLITCH_API_BASE_URL = 'https://api.glitch.fun/api';
+export const GLITCH_TITLE_ID = '6bd2c447-1770-441b-b94b-bceed5e81e87';
+
+const UUID = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+const CHECKSUM = /^[0-9a-f]{64}$/;
+const INSTALL_FIELDS = [
+  'user_install_id', 'user_id', 'user_email', 'user_name', 'platform',
+  'device_type', 'operating_system', 'game_build_id', 'game_version',
+  'build_type', 'device_id', 'referral_source', 'fingerprint_components',
+  'session_id'
+];
+const SAVE_FIELDS = [
+  'slot_index', 'payload', 'checksum', 'save_type', 'client_timestamp',
+  'base_version', 'slot_name', 'metadata', 'device_id', 'platform',
+  'game_version', 'last_played_at', 'play_duration_seconds'
+];
+const EVENT_FIELDS = [
+  'game_install_id', 'step_key', 'step_label', 'step_description',
+  'action_key', 'event_label', 'event_description', 'previous_step_key',
+  'metadata', 'event_timestamp'
+];
+
+class RequestError extends Error {
+  constructor(status, code, message) {
+    super(message);
+    this.status = status;
+    this.code = code;
+  }
+}
+
+function json(res, status, body, extraHeaders = {}) {
+  const data = Buffer.from(JSON.stringify(body));
+  res.writeHead(status, {
+    'Content-Type': 'application/json; charset=utf-8',
+    'Content-Length': data.length,
+    'Cache-Control': 'no-store',
+    ...extraHeaders
+  });
+  res.end(data);
+}
+
+function pick(source, fields) {
+  const result = {};
+  for (const field of fields) if (source[field] !== undefined) result[field] = source[field];
+  return result;
+}
+
+function assertString(value, name, max, required = false) {
+  if (value === undefined && !required) return;
+  if (typeof value !== 'string' || (required && !value) || value.length > max) {
+    throw new RequestError(422, 'VALIDATION_ERROR', `${name} is invalid.`);
+  }
+}
+
+function assertUuid(value, name) {
+  if (typeof value !== 'string' || !UUID.test(value)) {
+    throw new RequestError(422, 'VALIDATION_ERROR', `${name} must be a UUID.`);
+  }
+}
+
+function assertObject(value, name) {
+  if (value !== undefined && (value === null || Array.isArray(value) || typeof value !== 'object')) {
+    throw new RequestError(422, 'VALIDATION_ERROR', `${name} must be an object.`);
+  }
+}
+
+function validateInstall(body) {
+  const clean = pick(body, INSTALL_FIELDS);
+  assertString(clean.user_install_id, 'user_install_id', 255, true);
+  for (const field of ['user_email', 'user_name', 'device_type', 'operating_system', 'device_id', 'session_id']) {
+    assertString(clean[field], field, 255);
+  }
+  assertString(clean.platform, 'platform', 50);
+  assertString(clean.game_version, 'game_version', 50);
+  if (clean.user_id !== undefined) assertUuid(clean.user_id, 'user_id');
+  if (clean.game_build_id !== undefined) assertUuid(clean.game_build_id, 'game_build_id');
+  if (clean.build_type !== undefined && !['production', 'demo', 'playtest'].includes(clean.build_type)) {
+    throw new RequestError(422, 'VALIDATION_ERROR', 'build_type is invalid.');
+  }
+  if (clean.referral_source !== undefined &&
+      !['social_media', 'advertising', 'influencer', 'newsletter', 'word_of_mouth', 'other'].includes(clean.referral_source)) {
+    throw new RequestError(422, 'VALIDATION_ERROR', 'referral_source is invalid.');
+  }
+  assertObject(clean.fingerprint_components, 'fingerprint_components');
+  return clean;
+}
+
+function canonicalBase64(value) {
+  if (typeof value !== 'string' || value.length === 0 || value.length % 4 !== 0 ||
+      !/^[A-Za-z0-9+/]*={0,2}$/.test(value)) return null;
+  const bytes = Buffer.from(value, 'base64');
+  if (bytes.toString('base64') !== value) return null;
+  return bytes;
+}
+
+function validateSave(body) {
+  const clean = pick(body, SAVE_FIELDS);
+  if (!Number.isInteger(clean.slot_index) || clean.slot_index < 0 || clean.slot_index > 99) {
+    throw new RequestError(422, 'VALIDATION_ERROR', 'slot_index must be an integer from 0 to 99.');
+  }
+  const bytes = canonicalBase64(clean.payload);
+  if (!bytes) throw new RequestError(400, 'INVALID_BASE64', 'Save payload is not valid base64.');
+  if (bytes.length > 50 * 1024 * 1024) {
+    throw new RequestError(413, 'PAYLOAD_TOO_LARGE', 'Decoded save payload exceeds 50 MB.');
+  }
+  if (typeof clean.checksum !== 'string' || !CHECKSUM.test(clean.checksum)) {
+    throw new RequestError(422, 'VALIDATION_ERROR', 'checksum must be a lowercase SHA-256 value.');
+  }
+  const actual = createHash('sha256').update(bytes).digest('hex');
+  if (actual !== clean.checksum) {
+    throw new RequestError(400, 'CHECKSUM_MISMATCH', 'Save checksum does not match decoded bytes.');
+  }
+  if (!['manual', 'auto', 'checkpoint', 'quicksave'].includes(clean.save_type)) {
+    throw new RequestError(422, 'VALIDATION_ERROR', 'save_type is invalid.');
+  }
+  assertString(clean.client_timestamp, 'client_timestamp', 64, true);
+  if (!Number.isFinite(Date.parse(clean.client_timestamp))) {
+    throw new RequestError(422, 'VALIDATION_ERROR', 'client_timestamp must be ISO 8601.');
+  }
+  if (clean.base_version !== undefined && (!Number.isInteger(clean.base_version) || clean.base_version < 0)) {
+    throw new RequestError(422, 'VALIDATION_ERROR', 'base_version must be a non-negative integer.');
+  }
+  assertString(clean.slot_name, 'slot_name', 100);
+  assertString(clean.device_id, 'device_id', 255);
+  assertString(clean.platform, 'platform', 50);
+  assertString(clean.game_version, 'game_version', 50);
+  assertString(clean.last_played_at, 'last_played_at', 64);
+  if (clean.play_duration_seconds !== undefined &&
+      (!Number.isInteger(clean.play_duration_seconds) || clean.play_duration_seconds < 0)) {
+    throw new RequestError(422, 'VALIDATION_ERROR', 'play_duration_seconds must be a non-negative integer.');
+  }
+  assertObject(clean.metadata, 'metadata');
+  return clean;
+}
+
+function validateResolve(body) {
+  assertUuid(body.conflict_id, 'conflict_id');
+  if (!['keep_server', 'use_client'].includes(body.choice)) {
+    throw new RequestError(422, 'VALIDATION_ERROR', 'choice is invalid.');
+  }
+  return { conflict_id: body.conflict_id, choice: body.choice };
+}
+
+function validateEvent(body) {
+  const clean = pick(body, EVENT_FIELDS);
+  assertUuid(clean.game_install_id, 'game_install_id');
+  assertString(clean.step_key, 'step_key', 100, true);
+  assertString(clean.action_key, 'action_key', 100, true);
+  assertString(clean.step_label, 'step_label', 255);
+  assertString(clean.step_description, 'step_description', 2000);
+  assertString(clean.event_label, 'event_label', 255);
+  assertString(clean.event_description, 'event_description', 2000);
+  assertString(clean.previous_step_key, 'previous_step_key', 100);
+  assertString(clean.event_timestamp, 'event_timestamp', 64);
+  assertObject(clean.metadata, 'metadata');
+  return clean;
+}
+
+async function readJson(req, maxBytes) {
+  const type = String(req.headers['content-type'] || '').split(';')[0].trim();
+  if (type !== 'application/json') {
+    throw new RequestError(415, 'UNSUPPORTED_MEDIA_TYPE', 'Use application/json.');
+  }
+  const chunks = [];
+  let size = 0;
+  for await (const chunk of req) {
+    size += chunk.length;
+    if (size > maxBytes) throw new RequestError(413, 'PAYLOAD_TOO_LARGE', 'Request body is too large.');
+    chunks.push(chunk);
+  }
+  try {
+    const parsed = JSON.parse(Buffer.concat(chunks).toString('utf8') || '{}');
+    if (!parsed || Array.isArray(parsed) || typeof parsed !== 'object') throw new Error('object required');
+    return parsed;
+  } catch {
+    throw new RequestError(400, 'INVALID_JSON', 'Request body must be a JSON object.');
+  }
+}
+
+function requestOrigin(req) {
+  const value = req.headers.origin;
+  if (!value) return null;
+  try { return new URL(value).origin; } catch { return 'invalid'; }
+}
+
+function originAllowed(req, config) {
+  const origin = requestOrigin(req);
+  if (!origin) return true;
+  if (origin === 'invalid') return false;
+  const originHost = new URL(origin).host;
+  const hosts = [req.headers.host, req.headers['x-forwarded-host']].filter(Boolean);
+  if (hosts.includes(originHost)) return true;
+  return config.allowedOrigins.includes(origin);
+}
+
+function corsHeaders(req, config) {
+  const origin = requestOrigin(req);
+  if (!origin || !config.allowedOrigins.includes(origin)) return {};
+  return {
+    'Access-Control-Allow-Origin': origin,
+    'Access-Control-Allow-Methods': 'GET, POST, OPTIONS',
+    'Access-Control-Allow-Headers': 'Content-Type',
+    'Vary': 'Origin'
+  };
+}
+
+function makeRateLimiter(limit, windowMs) {
+  const clients = new Map();
+  return (key, now = Date.now()) => {
+    const current = clients.get(key);
+    if (!current || current.resetAt <= now) {
+      clients.set(key, { count: 1, resetAt: now + windowMs });
+      return null;
+    }
+    current.count++;
+    if (current.count <= limit) return null;
+    return Math.max(1, Math.ceil((current.resetAt - now) / 1000));
+  };
+}
+
+async function sendUpstream(res, config, fetchImpl, method, path, body, headers = {}) {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), config.requestTimeoutMs);
+  try {
+    const upstream = await fetchImpl(`${config.apiBaseUrl}${path}`, {
+      method,
+      headers: {
+        Accept: 'application/json',
+        Authorization: `Bearer ${config.titleToken}`,
+        ...(body === undefined ? {} : { 'Content-Type': 'application/json' })
+      },
+      body: body === undefined ? undefined : JSON.stringify(body),
+      redirect: 'error',
+      signal: controller.signal
+    });
+    const data = Buffer.from(await upstream.arrayBuffer());
+    res.writeHead(upstream.status, {
+      'Content-Type': upstream.headers.get('content-type') || 'application/json; charset=utf-8',
+      'Content-Length': data.length,
+      'Cache-Control': 'no-store',
+      ...headers
+    });
+    res.end(data);
+  } catch (error) {
+    const timedOut = error?.name === 'AbortError';
+    json(res, timedOut ? 504 : 502, {
+      code: timedOut ? 'UPSTREAM_TIMEOUT' : 'UPSTREAM_UNAVAILABLE',
+      message: timedOut ? 'Glitch did not respond in time.' : 'Glitch is temporarily unavailable.'
+    }, headers);
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+export function createGlitchProxy({ config, fetchImpl = globalThis.fetch }) {
+  const rateLimit = makeRateLimiter(config.rateLimitPerMinute, 60_000);
+
+  return async function handleGlitchRequest(req, res, url) {
+    if (!url.pathname.startsWith('/api/glitch/')) return false;
+    const extraHeaders = corsHeaders(req, config);
+
+    if (!config.enabled) {
+      json(res, 404, { code: 'BACKEND_DISABLED', message: 'Online services are not enabled.' });
+      return true;
+    }
+    if (!originAllowed(req, config)) {
+      json(res, 403, { code: 'ORIGIN_NOT_ALLOWED', message: 'This origin cannot use online services.' });
+      return true;
+    }
+    if (req.method === 'OPTIONS') {
+      res.writeHead(204, extraHeaders);
+      res.end();
+      return true;
+    }
+
+    const ip = req.socket.remoteAddress || 'unknown';
+    const retryAfter = rateLimit(ip);
+    if (retryAfter) {
+      json(res, 429, { code: 'RATE_LIMITED', message: 'Too many requests. Try again shortly.' },
+        { ...extraHeaders, 'Retry-After': retryAfter });
+      return true;
+    }
+
+    try {
+      let match;
+      if (req.method === 'POST' && url.pathname === '/api/glitch/installs') {
+        const body = validateInstall(await readJson(req, 128 * 1024));
+        await sendUpstream(res, config, fetchImpl, 'POST',
+          `/titles/${config.titleId}/installs`, body, extraHeaders);
+        return true;
+      }
+      if (req.method === 'POST' &&
+          (match = url.pathname.match(/^\/api\/glitch\/installs\/([^/]+)\/validate$/))) {
+        assertUuid(match[1], 'install_id');
+        await readJson(req, 16 * 1024);
+        await sendUpstream(res, config, fetchImpl, 'POST',
+          `/titles/${config.titleId}/installs/${match[1]}/validate`, {}, extraHeaders);
+        return true;
+      }
+      if (req.method === 'GET' &&
+          (match = url.pathname.match(/^\/api\/glitch\/installs\/([^/]+)\/saves$/))) {
+        if (!config.cloudSavesEnabled) throw new RequestError(404, 'CLOUD_SAVES_DISABLED', 'Cloud saves are not enabled.');
+        assertUuid(match[1], 'install_id');
+        const include = url.searchParams.get('include_payload');
+        const query = include === '0' || include === '1' ? `?include_payload=${include}` : '';
+        await sendUpstream(res, config, fetchImpl, 'GET',
+          `/titles/${config.titleId}/installs/${match[1]}/saves${query}`, undefined, extraHeaders);
+        return true;
+      }
+      if (req.method === 'POST' &&
+          (match = url.pathname.match(/^\/api\/glitch\/installs\/([^/]+)\/saves$/))) {
+        if (!config.cloudSavesEnabled) throw new RequestError(404, 'CLOUD_SAVES_DISABLED', 'Cloud saves are not enabled.');
+        assertUuid(match[1], 'install_id');
+        const body = validateSave(await readJson(req, 70 * 1024 * 1024));
+        await sendUpstream(res, config, fetchImpl, 'POST',
+          `/titles/${config.titleId}/installs/${match[1]}/saves`, body, extraHeaders);
+        return true;
+      }
+      if (req.method === 'POST' &&
+          (match = url.pathname.match(/^\/api\/glitch\/installs\/([^/]+)\/saves\/([^/]+)\/resolve$/))) {
+        if (!config.cloudSavesEnabled) throw new RequestError(404, 'CLOUD_SAVES_DISABLED', 'Cloud saves are not enabled.');
+        assertUuid(match[1], 'install_id');
+        assertUuid(match[2], 'save_id');
+        const body = validateResolve(await readJson(req, 32 * 1024));
+        await sendUpstream(res, config, fetchImpl, 'POST',
+          `/titles/${config.titleId}/installs/${match[1]}/saves/${match[2]}/resolve`, body, extraHeaders);
+        return true;
+      }
+      if (req.method === 'POST' && url.pathname === '/api/glitch/events') {
+        if (!config.analyticsEnabled) throw new RequestError(404, 'ANALYTICS_DISABLED', 'Behavior analytics are not enabled.');
+        const body = validateEvent(await readJson(req, 128 * 1024));
+        await sendUpstream(res, config, fetchImpl, 'POST',
+          `/titles/${config.titleId}/events`, body, extraHeaders);
+        return true;
+      }
+      json(res, 404, { code: 'NOT_FOUND', message: 'Online-service route not found.' }, extraHeaders);
+      return true;
+    } catch (error) {
+      if (error instanceof RequestError) {
+        json(res, error.status, { code: error.code, message: error.message }, extraHeaders);
+        return true;
+      }
+      json(res, 500, { code: 'BACKEND_ERROR', message: 'Online services could not process the request.' }, extraHeaders);
+      return true;
+    }
+  };
+}

--- a/backend/runtime-secrets.example.json
+++ b/backend/runtime-secrets.example.json
@@ -1,0 +1,7 @@
+{
+  "GLITCH_BACKEND_ENABLED": "1",
+  "GLITCH_TITLE_TOKEN": "set-this-only-in-a-private-deployment-copy",
+  "NODE_ENV": "production",
+  "GLITCH_CLOUD_SAVES_ENABLED": "1",
+  "GLITCH_ANALYTICS_ENABLED": "1"
+}

--- a/backend/runtime-secrets.example.json
+++ b/backend/runtime-secrets.example.json
@@ -2,6 +2,5 @@
   "GLITCH_BACKEND_ENABLED": "1",
   "GLITCH_TITLE_TOKEN": "set-this-only-in-a-private-deployment-copy",
   "NODE_ENV": "production",
-  "GLITCH_CLOUD_SAVES_ENABLED": "1",
-  "GLITCH_ANALYTICS_ENABLED": "1"
+  "GLITCH_CLOUD_SAVES_ENABLED": "1"
 }

--- a/docs/GLITCH_PLAY_INCIDENT_2026-08-13.md
+++ b/docs/GLITCH_PLAY_INCIDENT_2026-08-13.md
@@ -1,8 +1,43 @@
 # Glitch public play incident — Regolith
 
+## Resolution status
+
+**Resolved and verified on August 13, 2026 at 04:21 UTC.**
+
+The Glitch platform fixes were deployed, and Regolith was redeployed from commit `82f927f` as:
+
+| Resource | Resolved value |
+| --- | --- |
+| Glitch build | `019ff951-7bc9-73f3-a127-57779898a0ef` |
+| Deployment label | `1.1.2-redeploy` |
+| Runtime game version | `1.1.2` |
+| Title deployment type | `node` |
+| Build deployment type | `node` |
+| Build state | `ready`, active |
+| Azure revision | `regolith-node--0000002` |
+| Azure health | Healthy, two replicas, 100% traffic |
+
+Resolution verification in an authenticated Glitch browser session:
+
+1. The server-rendered title metadata reported `deployment_type: "node"`.
+2. The new active build reported `deployment_type: "node"`, `status: "ready"`, and the correct Node CDN URL.
+3. `POST /api/titles/6bd2c447-1770-441b-b94b-bceed5e81e87/play` returned HTTP 200 at 04:14:31 UTC.
+4. The page created a visible iframe titled `Regolith` whose source was the production Node URL.
+5. The page did not display Aegis, GPU allocation, OS boot, timeout, or no-active-build messaging.
+6. The embedded game completed validation and displayed `Online services connected.`
+7. The main menu rendered and **Begin Descent** successfully entered Mission 01.
+8. Validation calls returned HTTP 200 and behavior events returned HTTP 201.
+
+The original root-cause report below remains as the historical incident record and durable prevention guidance.
+
+### Remaining verification notes
+
+- The title still reports `is_live: false`, `approval_status: 0`, `requires_distribution_fee: true`, and `has_distribution_fee_access: false`. The authenticated developer flow works, but anonymous/non-developer availability was not proven and should be checked against Glitch's publishing rules.
+- The controlled Chrome test session could not acquire Pointer Lock and logged `WrongDocumentError`. The same result occurred on the direct top-level Node URL, not only inside Glitch's iframe, while the canvas remained connected and visible. This does not indicate a recurrence of the launcher incident, but a manual human mouse-look check is still recommended.
+
 ## Incident summary
 
-As of August 13, 2026 at 01:58 UTC, Regolith's public Glitch play page cannot launch the game even though the active Node build and its Azure Container App are healthy.
+On August 13, 2026 at 01:58 UTC, Regolith's public Glitch play page could not launch the game even though the active Node build and its Azure Container App were healthy.
 
 The failure is a Glitch platform metadata/routing inconsistency:
 
@@ -13,16 +48,16 @@ The failure is a Glitch platform metadata/routing inconsistency:
 
 This report contains no title token, distribution token, session credential, private header, or player identifier.
 
-## Impact
+## Impact during the incident
 
-- Public players cannot start Regolith from the Glitch play page.
-- The launch screen remains in the Aegis allocation/boot sequence and can eventually report that the server took too long to start.
-- The game's direct production URL works normally, so the outage is isolated to Glitch's title-to-build launch routing.
-- Install validation, behavior analytics, and the Node application remain operational when the direct production URL is used.
+- Public players could not start Regolith from the Glitch play page.
+- The launch screen remained in the Aegis allocation/boot sequence and could eventually report that the server took too long to start.
+- The game's direct production URL worked normally, so the outage was isolated to Glitch's title-to-build launch routing.
+- Install validation, behavior analytics, and the Node application remained operational when the direct production URL was used.
 
-Suggested severity: **High — production launch blocked for all public Glitch play-page users**.
+Incident severity: **High — production launch blocked for Glitch play-page users**.
 
-## Affected resources
+## Affected resources at incident time
 
 | Resource | Value |
 | --- | --- |
@@ -39,9 +74,9 @@ Suggested severity: **High — production launch blocked for all public Glitch p
 | Active Azure revision | `regolith-node--0000001` |
 | Active image | `glitchgames.azurecr.io/regolith-node:1786585979` |
 
-## Current inconsistent state
+## State observed during the incident
 
-The server-rendered `window.__ROUTE_DATA__` on the public play page reports this state:
+The server-rendered `window.__ROUTE_DATA__` on the public play page reported this state:
 
 | Field | Title record | Active build |
 | --- | --- | --- |

--- a/docs/GLITCH_PLAY_INCIDENT_2026-08-13.md
+++ b/docs/GLITCH_PLAY_INCIDENT_2026-08-13.md
@@ -1,0 +1,311 @@
+# Glitch public play incident — Regolith
+
+## Incident summary
+
+As of August 13, 2026 at 01:58 UTC, Regolith's public Glitch play page cannot launch the game even though the active Node build and its Azure Container App are healthy.
+
+The failure is a Glitch platform metadata/routing inconsistency:
+
+- the title record advertises `deployment_type: "wasm"`;
+- the active, ready build advertises `deployment_type: "node"` and has a working `cdn_url`;
+- the public play flow follows the title-level WASM classification and starts an Aegis GPU/OS streaming session;
+- it never embeds or navigates to the healthy Node build URL.
+
+This report contains no title token, distribution token, session credential, private header, or player identifier.
+
+## Impact
+
+- Public players cannot start Regolith from the Glitch play page.
+- The launch screen remains in the Aegis allocation/boot sequence and can eventually report that the server took too long to start.
+- The game's direct production URL works normally, so the outage is isolated to Glitch's title-to-build launch routing.
+- Install validation, behavior analytics, and the Node application remain operational when the direct production URL is used.
+
+Suggested severity: **High — production launch blocked for all public Glitch play-page users**.
+
+## Affected resources
+
+| Resource | Value |
+| --- | --- |
+| Glitch title | Regolith |
+| Title ID | `6bd2c447-1770-441b-b94b-bceed5e81e87` |
+| Public play page | `https://www.glitch.fun/games/6bd2c447-1770-441b-b94b-bceed5e81e87/play` |
+| Active build | `019ff8d1-faa2-7180-99a8-16da93dc915c` |
+| Active version | `1.1.2` |
+| Active build type | `node` |
+| Active build status | `ready` |
+| Active build URL | `https://regolith-node.graywater-acc59434.eastus.azurecontainerapps.io` |
+| Azure Container App | `regolith-node` |
+| Azure resource group | `openai-resource-group` |
+| Active Azure revision | `regolith-node--0000001` |
+| Active image | `glitchgames.azurecr.io/regolith-node:1786585979` |
+
+## Current inconsistent state
+
+The server-rendered `window.__ROUTE_DATA__` on the public play page reports this state:
+
+| Field | Title record | Active build |
+| --- | --- | --- |
+| ID | `6bd2c447-1770-441b-b94b-bceed5e81e87` | `019ff8d1-faa2-7180-99a8-16da93dc915c` |
+| Deployment type | `wasm` | `node` |
+| Status | `is_live: false`, `approval_status: 0` | `status: ready`, `is_active: true` |
+| Version | n/a | `1.1.2` |
+| CDN URL | n/a | `https://regolith-node.graywater-acc59434.eastus.azurecontainerapps.io` |
+| Build error | n/a | `null` |
+
+The same route data also reports `requires_distribution_fee: true` and `has_distribution_fee_access: false`. Those flags and `is_live: false` should be reviewed against Glitch's publishing rules, but they do not explain why the client explicitly enters the Aegis path. The direct evidence for that branch is the stale title-level `deployment_type: "wasm"` while the active build is `node`.
+
+## Reproduction
+
+Reproduced after version 1.1.2 was active:
+
+1. Open the public play page.
+2. Wait for Clip Studio and the **Play Full Game** button.
+3. Select **Play Full Game**.
+4. Observe the launch overlay.
+
+Actual result:
+
+```text
+CONNECTING...ALLOCATING GPU...
+Starting a secure play session. Aegis is spinning up a dedicated instance.
+Game loading: 8%
+Initializing Aegis Session...
+```
+
+On an earlier attempt, the progress advanced through GPU allocation and OS boot, then stopped. The final player-facing failure was:
+
+```text
+UNABLE TO START GAME
+Server took too long to start. Please try again.
+The developer needs to publish an active build before this game can be launched.
+```
+
+During the failing launch:
+
+- there was no iframe whose source was the Regolith Node URL;
+- the only iframes were hidden Stripe support frames;
+- no Regolith canvas was created;
+- the browser console showed no application error explaining the failure;
+- the Glitch API accepted the play request with HTTP 200.
+
+Expected result:
+
+- the play flow should recognize the active build as `node`;
+- it should embed or navigate to the active build's `cdn_url`;
+- Regolith should reach its menu after online install validation.
+
+## Evidence that the game deployment is healthy
+
+### Direct application checks
+
+The production origin returned HTTP 200 for the root document, runtime configuration, game entry module, and vendored Three.js assets. The generated runtime configuration was:
+
+```json
+{
+  "glitch": {
+    "enabled": true,
+    "titleId": "6bd2c447-1770-441b-b94b-bceed5e81e87",
+    "environment": "production",
+    "apiOrigin": "",
+    "cloudSavesEnabled": true,
+    "analyticsEnabled": true,
+    "gameVersion": "1.1.2",
+    "buildType": "production"
+  }
+}
+```
+
+A browser opened the direct origin, completed install validation, removed the boot overlay, and displayed the normal main menu. It did not show an analytics consent prompt or analytics setting.
+
+### Azure Container App health
+
+Azure reported:
+
+```text
+provisioningState: Succeeded
+runningStatus: Running
+active revision: regolith-node--0000001
+revision health: Healthy
+replicas: 2
+traffic: 100%
+```
+
+Both replicas pulled the production image and started. Application console output reported:
+
+```text
+REGOLITH — The Silence at Anaxagoras
+running at  http://localhost:3000
+online services  enabled
+```
+
+Each replica had one transient startup-probe warning approximately one second before the process logged that it was listening. Azure then completed the rolling transition, marked the revision healthy, and routed 100% of traffic to it. There was no crash loop, termination, failed image pull, application exception, or sustained probe failure.
+
+### Glitch API behavior
+
+The production play request issued during the August 13 reproduction was accepted:
+
+```text
+2026-08-13T01:57:57Z  POST /api/titles/6bd2c447-1770-441b-b94b-bceed5e81e87/play  200  3.09s
+```
+
+The automatic behavior event emitted by the direct Node application was also accepted:
+
+```text
+2026-08-13T01:55:38Z  POST /api/titles/6bd2c447-1770-441b-b94b-bceed5e81e87/events  201  1.517s
+```
+
+These results show that Glitch's API is reachable and the application can use its configured online-service credentials. The failure occurs after the play endpoint succeeds and before the browser launches the active Node URL.
+
+## Timeline in UTC
+
+| Time | Event |
+| --- | --- |
+| 2026-08-13 01:29:26 | Version 1.1.0 Node build created; failed because the first upload did not contain the required root `Dockerfile`. |
+| 2026-08-13 01:30:26 | Version 1.1.1 Node build created and later became ready. |
+| 2026-08-13 01:31:13 | Azure revision `regolith-node--32yhtwj` created and became healthy. |
+| 2026-08-13 01:46:29 | Public play request returned HTTP 200, but the UI remained in Aegis streaming startup. |
+| 2026-08-13 01:52:18 | Version 1.1.2 Node build created. |
+| 2026-08-13 01:53:39 | Azure revision `regolith-node--0000001` created. |
+| 2026-08-13 01:53:57 | Regolith 1.1.2 logged that it was listening with online services enabled. |
+| 2026-08-13 01:54:04 | Azure completed the rolling transition. |
+| 2026-08-13 01:55:38 | Automatic behavior event returned HTTP 201. |
+| 2026-08-13 01:57:57 | Failure reproduced again after 1.1.2 activation; `/play` returned HTTP 200 and the UI launched Aegis instead of the Node build. |
+
+## Root-cause assessment
+
+### Most likely root cause
+
+Glitch's title record retained `deployment_type: "wasm"` after a ready Node build was activated. The play-page client or the `/play` session-selection code appears to branch on the title-level field rather than the active build's field. It therefore creates an Aegis streaming session appropriate for a WASM/native-streamed title instead of using the active Node build's `cdn_url`.
+
+Confidence: **high**.
+
+Supporting facts:
+
+1. The title/build deployment-type mismatch is present in the page's own route data.
+2. The visible flow explicitly says it is allocating a GPU, booting an OS, and initializing Aegis.
+3. No game iframe or navigation to the Node CDN occurs.
+4. The active build is ready, active, and has a valid CDN URL.
+5. The CDN URL serves the complete game successfully.
+6. The `/play` API call returns HTTP 200 instead of reporting an application deployment failure.
+
+### Ruled-out or unlikely causes
+
+- **Regolith process crash:** ruled out by healthy replicas, successful direct requests, and the working menu.
+- **Missing active build:** ruled out by `is_active: true`, `status: ready`, and the active CDN URL in route data.
+- **Bad container port:** ruled out by successful direct HTTPS requests through Azure ingress and the process listening on port 3000.
+- **Broken game assets:** ruled out by HTTP 200 asset responses and successful direct browser startup.
+- **Invalid runtime title token:** ruled out by successful install validation and HTTP 201 behavior events through the server-side proxy.
+- **Analytics changes:** unrelated; the same Aegis misrouting occurred with version 1.1.1 and after version 1.1.2 became active.
+
+## Required Glitch-side remediation
+
+### Immediate data repair
+
+For title `6bd2c447-1770-441b-b94b-bceed5e81e87`, set the title's effective deployment type to `node`, consistent with active build `019ff8d1-faa2-7180-99a8-16da93dc915c`. Then invalidate any title/play-page cache and server-rendered route-data cache.
+
+Also review whether `is_live`, `approval_status`, `requires_distribution_fee`, and `has_distribution_fee_access` block publication under current business rules. If those values are intended to prevent launch, the UI and `/play` API should return that explicit policy error instead of starting Aegis and eventually claiming that no active build exists.
+
+### Durable application fix
+
+Glitch should make the active build authoritative for runtime selection:
+
+1. Resolve the active build inside the play endpoint or launch service.
+2. Read `deployment_type` and `cdn_url` from that active build.
+3. For `node`, return the Node/web launch configuration and never allocate Aegis.
+4. For a streaming build type, create the Aegis session only when the active build itself requires it.
+5. If title and active-build deployment types disagree, fail closed with a specific internal configuration error and emit an alert.
+
+If the product requires a denormalized title-level deployment type, update it transactionally whenever an active build is confirmed or activated:
+
+```text
+begin transaction
+  lock title
+  deactivate prior active build
+  activate selected ready build
+  set title.deployment_type = selected_build.deployment_type
+  update title.active_build_id = selected_build.id
+commit
+invalidate title and play-page caches
+```
+
+The activation endpoint should reject builds that are not ready and should verify the invariant immediately after commit:
+
+```text
+title.deployment_type == active_build.deployment_type
+```
+
+### Frontend safety fix
+
+The play page should not select its launcher solely from stale server-rendered title metadata. It should use the launch type returned by the successful `/play` request, or fetch the current active build immediately before launch. For a Node launch it should create an iframe or navigate to the returned CDN URL. Aegis-specific progress text must appear only for a confirmed Aegis session.
+
+### Observability and tests
+
+Add structured fields to play/session logs:
+
+- `title_id`
+- `active_build_id`
+- `title_deployment_type`
+- `build_deployment_type`
+- `selected_launcher`
+- `cdn_url_present`
+- `is_live`
+- `approval_status`
+- `distribution_access_state`
+
+Add an alert for title/build deployment-type mismatch and a metric for `/play` requests that return HTTP 200 but never reach either a Node iframe-ready event or an Aegis stream-ready event.
+
+Recommended regression tests:
+
+1. Activate a ready Node build on a title previously marked WASM; verify the next play launches the Node URL.
+2. Activate a streaming build on a title previously marked Node; verify Aegis is selected.
+3. Simulate stale route-data cache; verify the `/play` response remains authoritative.
+4. Verify a title with no active ready build returns a precise non-200 launch error.
+5. Verify policy blocks such as distribution access return the policy error and do not start Aegis.
+6. Verify activation updates title/build metadata atomically and cache invalidation occurs.
+
+## Verification checklist after the fix
+
+- [ ] Public route data reports title `deployment_type: "node"`.
+- [ ] Active build remains `019ff8d1-faa2-7180-99a8-16da93dc915c`, `ready`, and active.
+- [ ] Selecting **Play Full Game** does not show GPU allocation, OS boot, or Aegis messages.
+- [ ] The browser embeds or navigates to `https://regolith-node.graywater-acc59434.eastus.azurecontainerapps.io`.
+- [ ] The Regolith menu appears.
+- [ ] Azure application access/console logs receive the play-page request.
+- [ ] Install validation succeeds.
+- [ ] The automatic `app_launch/session_started` event returns HTTP 201.
+- [ ] Refreshing the play page preserves the corrected launch path, proving cache invalidation.
+
+## Diagnostic commands used
+
+The following commands are safe examples and contain no credentials:
+
+```bash
+az containerapp show \
+  --resource-group openai-resource-group \
+  --name regolith-node
+
+az containerapp revision list \
+  --resource-group openai-resource-group \
+  --name regolith-node
+
+az containerapp logs show \
+  --resource-group openai-resource-group \
+  --name regolith-node \
+  --type console \
+  --tail 50
+
+az containerapp logs show \
+  --resource-group openai-resource-group \
+  --name regolith-node \
+  --type system \
+  --tail 50
+
+curl -I https://regolith-node.graywater-acc59434.eastus.azurecontainerapps.io/
+curl https://regolith-node.graywater-acc59434.eastus.azurecontainerapps.io/runtime-config.js
+```
+
+The Glitch API access-log query filtered `ContainerAppConsoleLogs_CL` to the title's `/play` and `/events` routes. Credentials and request bodies were not printed or retained.
+
+## Ownership boundary
+
+The game repository can ensure that a valid Node build is produced, that its direct URL works, and that credentials stay server-side. It cannot safely correct Glitch's persisted title metadata or launcher-selection logic. The immediate metadata repair and durable routing fix require the Glitch platform team or an authorized Glitch administrative control plane.

--- a/docs/ONLINE_SERVICES.md
+++ b/docs/ONLINE_SERVICES.md
@@ -4,17 +4,16 @@ Regolith 1.1 adds an optional same-origin Node backend for Glitch install valida
 
 ## Current production deployment
 
-- Version: `1.1.2`
-- Deployment label: `1.1.2-redeploy`
-- Active Glitch build: `019ff951-7bc9-73f3-a127-57779898a0ef`
-- Previous Glitch build: `019ff8d1-faa2-7180-99a8-16da93dc915c` (`1.1.2`)
+- Version: `1.1.3`
+- Active Glitch build: `019ff9e2-aafa-70c1-8402-c5d7ca46513b`
+- Previous Glitch build: `019ff951-7bc9-73f3-a127-57779898a0ef` (`1.1.2-redeploy`)
 - Deployment type: `node`
 - Build type: `production`
-- Status verified on August 13, 2026 at 04:21 UTC: `ready`, active
-- Azure revision: `regolith-node--0000002`, healthy, two replicas, 100% traffic
+- Status verified on August 13, 2026 at 06:56 UTC: `ready`, active
+- Azure revision: `regolith-node--0000003`, healthy, two replicas, 100% traffic
 - Runtime URL: `https://regolith-node.graywater-acc59434.eastus.azurecontainerapps.io`
 
-The post-deploy smoke test verified that runtime configuration was enabled without exposing a token, the direct runtime loaded through the main menu, install validation returned `valid: true`, and behavior events returned HTTP 201 without a consent prompt. The authenticated Glitch play page returned HTTP 200 from `/play`, embedded the Node URL in a visible Regolith iframe, reported `Online services connected`, and entered Mission 01 without showing Aegis/GPU startup or a launch error.
+The post-deploy smoke test verified that runtime configuration reported version 1.1.3 without exposing a token, the direct runtime loaded through the main menu, install validation returned HTTP 200, and behavior events returned HTTP 201. The authenticated Glitch play page embedded the Node URL in a visible Regolith iframe without showing Aegis/GPU startup or a launch error. Production HTML and the rendered game contain no cloud-versus-device choice; automatic cloud-authoritative conflict behavior is covered by the 26-test suite.
 
 The previous Glitch metadata/routing incident is resolved. See [Glitch public play incident — August 13, 2026](GLITCH_PLAY_INCIDENT_2026-08-13.md) for the original evidence, platform remediation, and resolution verification. The title still reports `is_live: false`, `approval_status: 0`, and no distribution-fee access, so an anonymous/non-developer launch remains a separate publishing-policy check.
 

--- a/docs/ONLINE_SERVICES.md
+++ b/docs/ONLINE_SERVICES.md
@@ -5,16 +5,18 @@ Regolith 1.1 adds an optional same-origin Node backend for Glitch install valida
 ## Current production deployment
 
 - Version: `1.1.2`
-- Active Glitch build: `019ff8d1-faa2-7180-99a8-16da93dc915c`
-- Previous Glitch build: `019ff8bd-f4a9-7395-b93d-bbdee96ba609` (`1.1.1`)
+- Deployment label: `1.1.2-redeploy`
+- Active Glitch build: `019ff951-7bc9-73f3-a127-57779898a0ef`
+- Previous Glitch build: `019ff8d1-faa2-7180-99a8-16da93dc915c` (`1.1.2`)
 - Deployment type: `node`
 - Build type: `production`
-- Status verified on August 13, 2026 at 01:58 UTC: `ready`, active
+- Status verified on August 13, 2026 at 04:21 UTC: `ready`, active
+- Azure revision: `regolith-node--0000002`, healthy, two replicas, 100% traffic
 - Runtime URL: `https://regolith-node.graywater-acc59434.eastus.azurecontainerapps.io`
 
-The post-deploy smoke test verified that runtime configuration was enabled without exposing a token, the direct runtime loaded through the main menu, install validation returned `valid: true`, and the automatic `app_launch/session_started` behavior event returned HTTP 201 without a consent prompt. The smoke-test install was a guest, so Cloud Save returned the documented HTTP 403 `GUEST_NOT_ALLOWED`; successful and conflict cloud-save paths are covered by the automated test suite with a login-backed install response.
+The post-deploy smoke test verified that runtime configuration was enabled without exposing a token, the direct runtime loaded through the main menu, install validation returned `valid: true`, and behavior events returned HTTP 201 without a consent prompt. The authenticated Glitch play page returned HTTP 200 from `/play`, embedded the Node URL in a visible Regolith iframe, reported `Online services connected`, and entered Mission 01 without showing Aegis/GPU startup or a launch error.
 
-The Glitch public play page remains blocked by a platform metadata/routing mismatch even though the Node runtime is healthy. See [Glitch public play incident — August 13, 2026](GLITCH_PLAY_INCIDENT_2026-08-13.md) for the full evidence and recommended Glitch-side fix.
+The previous Glitch metadata/routing incident is resolved. See [Glitch public play incident — August 13, 2026](GLITCH_PLAY_INCIDENT_2026-08-13.md) for the original evidence, platform remediation, and resolution verification. The title still reports `is_live: false`, `approval_status: 0`, and no distribution-fee access, so an anonymous/non-developer launch remains a separate publishing-policy check.
 
 ## Architecture
 

--- a/docs/ONLINE_SERVICES.md
+++ b/docs/ONLINE_SERVICES.md
@@ -4,14 +4,17 @@ Regolith 1.1 adds an optional same-origin Node backend for Glitch install valida
 
 ## Current production deployment
 
-- Version: `1.1.1`
-- Glitch build: `019ff8bd-f4a9-7395-b93d-bbdee96ba609`
+- Version: `1.1.2`
+- Active Glitch build: `019ff8d1-faa2-7180-99a8-16da93dc915c`
+- Previous Glitch build: `019ff8bd-f4a9-7395-b93d-bbdee96ba609` (`1.1.1`)
 - Deployment type: `node`
 - Build type: `production`
-- Status verified on August 13, 2026: `ready`
+- Status verified on August 13, 2026 at 01:58 UTC: `ready`, active
 - Runtime URL: `https://regolith-node.graywater-acc59434.eastus.azurecontainerapps.io`
 
-The post-deploy smoke test verified that runtime configuration was enabled without exposing a token, server-only paths returned 404, install creation succeeded, install validation returned `valid: true`, and a behavior event returned HTTP 201. The smoke-test install was a guest, so Cloud Save returned the documented HTTP 403 `GUEST_NOT_ALLOWED`; successful and conflict cloud-save paths are covered by the automated test suite with a login-backed install response.
+The post-deploy smoke test verified that runtime configuration was enabled without exposing a token, the direct runtime loaded through the main menu, install validation returned `valid: true`, and the automatic `app_launch/session_started` behavior event returned HTTP 201 without a consent prompt. The smoke-test install was a guest, so Cloud Save returned the documented HTTP 403 `GUEST_NOT_ALLOWED`; successful and conflict cloud-save paths are covered by the automated test suite with a login-backed install response.
+
+The Glitch public play page remains blocked by a platform metadata/routing mismatch even though the Node runtime is healthy. See [Glitch public play incident — August 13, 2026](GLITCH_PLAY_INCIDENT_2026-08-13.md) for the full evidence and recommended Glitch-side fix.
 
 ## Architecture
 
@@ -41,10 +44,8 @@ Set these environment variables on a private server, or copy `backend/runtime-se
 | --- | --- | --- |
 | `GLITCH_BACKEND_ENABLED=1` | yes | Enables the proxy and client integration. |
 | `GLITCH_TITLE_TOKEN` | yes | Runtime install/title token. Server-only. |
-| `NODE_ENV=production` | for production analytics | Enables production behavior analytics. |
+| `NODE_ENV=production` | recommended | Marks the server runtime as production. |
 | `GLITCH_CLOUD_SAVES_ENABLED=0|1` | no | Defaults to enabled when the backend is enabled. |
-| `GLITCH_ANALYTICS_ENABLED=0|1` | no | Defaults to enabled, but still requires production or explicit test mode. |
-| `GLITCH_ANALYTICS_TEST_MODE=1` | tests only | Allows behavior events outside production. Never use for an ordinary development session. |
 | `REGOLITH_ALLOWED_ORIGINS` | no | Comma-separated additional trusted browser origins. Same-origin requests are always allowed. |
 | `REGOLITH_PUBLIC_API_ORIGIN` | no | Absolute game API origin when the frontend and Node server are intentionally hosted separately. |
 | `GLITCH_REQUEST_TIMEOUT_MS` | no | Upstream timeout; defaults to 10 seconds. |
@@ -72,7 +73,7 @@ The script creates its staging directory outside the repository, adds the runtim
 6. Recreate once when validation reports `INSTALL_NOT_FOUND`.
 7. Block play with a player-readable message for license, trial, subscription, age-gate, or suspension denials.
 8. If Glitch cannot be reached, a previously validated install receives a 24-hour offline grace period. A new/unvalidated install does not bypass validation.
-9. With analytics consent, reuse the same `user_install_id` and session ID for a heartbeat every 30 seconds.
+9. Reuse the same `user_install_id` and session ID for an always-on analytics heartbeat every 30 seconds.
 
 Cloud saves require a login-backed install with a Glitch `user_id`. Guest players continue with local saves and see a plain-language status message.
 
@@ -91,14 +92,12 @@ Cloud saves require a login-backed install with a Glitch `user_id`. Guest player
 
 ## Behavior analytics contract
 
-Events are sent only when all of these are true:
+Events are sent automatically when all of these are true:
 
 1. The optional backend is enabled.
-2. The server is in production, or isolated analytics test mode is explicitly enabled.
-3. Install validation succeeded online.
-4. The player opted in to usage analytics.
+2. Install validation succeeded online.
 
-Every event includes `game_install_id`, stable `step_key` and `action_key`, `event_timestamp`, `session_id`, `game_version`, and `build_type`. `previous_step_key` is included when the player changes steps. The client deduplicates repeated events, queues up to 100 events in memory, retries transient failures with bounded exponential backoff, and uses a keepalive flush for page exit.
+There is no consent prompt or settings toggle for Glitch behavior analytics. Every event includes `game_install_id`, stable `step_key` and `action_key`, `event_timestamp`, `session_id`, `game_version`, and `build_type`. `previous_step_key` is included when the player changes steps. The client deduplicates repeated events, queues up to 100 events in memory, retries transient failures with bounded exponential backoff, and uses a keepalive flush for page exit.
 
 Metadata is privacy-filtered. Passwords, tokens, secrets, email, chat/private messages, dialogue, player-entered text, raw exceptions, stack traces, and precise location are not sent.
 
@@ -136,7 +135,7 @@ The Node test suite covers:
 
 - optional/disabled behavior;
 - install creation, desktop launch IDs, validation, recreation, denial, and offline grace;
-- production and consent gates;
+- automatic analytics startup whenever Glitch is enabled;
 - event context, sensitive-field removal, duplicate prevention, and provider failure;
 - save encoding, decoded-byte checksum verification, upload fields, remote restore, and 409 resolution;
 - exact upstream routes and bearer placement;

--- a/docs/ONLINE_SERVICES.md
+++ b/docs/ONLINE_SERVICES.md
@@ -1,0 +1,151 @@
+# Regolith online services
+
+Regolith 1.1 adds an optional same-origin Node backend for Glitch install validation, cloud saves, retention heartbeats, and behavior analytics. The static game remains fully playable without it.
+
+## Current production deployment
+
+- Version: `1.1.1`
+- Glitch build: `019ff8bd-f4a9-7395-b93d-bbdee96ba609`
+- Deployment type: `node`
+- Build type: `production`
+- Status verified on August 13, 2026: `ready`
+- Runtime URL: `https://regolith-node.graywater-acc59434.eastus.azurecontainerapps.io`
+
+The post-deploy smoke test verified that runtime configuration was enabled without exposing a token, server-only paths returned 404, install creation succeeded, install validation returned `valid: true`, and a behavior event returned HTTP 201. The smoke-test install was a guest, so Cloud Save returned the documented HTTP 403 `GUEST_NOT_ALLOWED`; successful and conflict cloud-save paths are covered by the automated test suite with a login-backed install response.
+
+## Architecture
+
+Disabled/static deployment:
+
+```text
+Browser ── game files ──> static host
+Browser ── saves/settings ──> localStorage
+```
+
+Enabled Node deployment:
+
+```text
+Browser ── /api/glitch/* ──> Regolith Node server ── title token ──> Glitch API
+Browser ── local fallback ──> localStorage
+```
+
+The browser never receives the title token. The proxy only exposes the approved install, validation, cloud-save, conflict-resolution, and single-event routes. Unknown fields and arbitrary upstream paths are rejected.
+
+## Configuration
+
+The committed [runtime-config.js](../runtime-config.js) disables Glitch for ordinary static hosting. When the Node server is used, it generates that response from server configuration without including credentials.
+
+Set these environment variables on a private server, or copy `backend/runtime-secrets.example.json` to the ignored `backend/runtime-secrets.json` and fill it only in a private deployment artifact:
+
+| variable | required | purpose |
+| --- | --- | --- |
+| `GLITCH_BACKEND_ENABLED=1` | yes | Enables the proxy and client integration. |
+| `GLITCH_TITLE_TOKEN` | yes | Runtime install/title token. Server-only. |
+| `NODE_ENV=production` | for production analytics | Enables production behavior analytics. |
+| `GLITCH_CLOUD_SAVES_ENABLED=0|1` | no | Defaults to enabled when the backend is enabled. |
+| `GLITCH_ANALYTICS_ENABLED=0|1` | no | Defaults to enabled, but still requires production or explicit test mode. |
+| `GLITCH_ANALYTICS_TEST_MODE=1` | tests only | Allows behavior events outside production. Never use for an ordinary development session. |
+| `REGOLITH_ALLOWED_ORIGINS` | no | Comma-separated additional trusted browser origins. Same-origin requests are always allowed. |
+| `REGOLITH_PUBLIC_API_ORIGIN` | no | Absolute game API origin when the frontend and Node server are intentionally hosted separately. |
+| `GLITCH_REQUEST_TIMEOUT_MS` | no | Upstream timeout; defaults to 10 seconds. |
+| `GLITCH_RATE_LIMIT_PER_MINUTE` | no | Per-process API limit; defaults to 180 requests per client address. |
+
+The distribution/deploy token is never a runtime setting and must never be placed in the game ZIP.
+
+To package, upload, confirm, wait for processing, and activate a production Node build from a trusted machine:
+
+```bash
+GLITCH_DISTRIBUTION_TOKEN='private deploy token' \
+GLITCH_TITLE_TOKEN='private runtime title token' \
+npm run deploy:glitch
+```
+
+The script creates its staging directory outside the repository, adds the runtime title token only to an ignored server-only file in that temporary artifact, excludes the deploy token entirely, and removes the staging directory when it finishes.
+
+## Install and validation lifecycle
+
+1. Read Glitch Desktop launch parameters when present: `title_id`, `game_id`, `install_id`, `user_install_id`, and `session_id`.
+2. Otherwise create and persist one stable `user_install_id` and `device_id` in browser storage.
+3. Create or reuse the install with `POST /titles/{title_id}/installs`.
+4. Persist returned `data.id` as `install_id`.
+5. Validate with `POST /titles/{title_id}/installs/{install_id}/validate` before play.
+6. Recreate once when validation reports `INSTALL_NOT_FOUND`.
+7. Block play with a player-readable message for license, trial, subscription, age-gate, or suspension denials.
+8. If Glitch cannot be reached, a previously validated install receives a 24-hour offline grace period. A new/unvalidated install does not bypass validation.
+9. With analytics consent, reuse the same `user_install_id` and session ID for a heartbeat every 30 seconds.
+
+Cloud saves require a login-backed install with a Glitch `user_id`. Guest players continue with local saves and see a plain-language status message.
+
+## Cloud-save lifecycle
+
+- Slot `0` is Regolith's autosave slot.
+- Local saves continue every 20 seconds and on exit.
+- The cloud payload is base64 of the raw UTF-8 JSON save bytes.
+- The checksum is lowercase SHA-256 of those raw decoded bytes.
+- The last synchronized server version is persisted and sent as `base_version`.
+- Matching checksums are deduplicated.
+- A remote-only save is restored locally after its checksum is verified.
+- A local-only or locally newer save uploads in the background.
+- A 409 conflict opens a player choice between `keep_server` and `use_client`, then calls the documented resolve endpoint. No conflict is overwritten silently.
+- A blocked, failed, or offline provider leaves the local save intact and never pauses gameplay.
+
+## Behavior analytics contract
+
+Events are sent only when all of these are true:
+
+1. The optional backend is enabled.
+2. The server is in production, or isolated analytics test mode is explicitly enabled.
+3. Install validation succeeded online.
+4. The player opted in to usage analytics.
+
+Every event includes `game_install_id`, stable `step_key` and `action_key`, `event_timestamp`, `session_id`, `game_version`, and `build_type`. `previous_step_key` is included when the player changes steps. The client deduplicates repeated events, queues up to 100 events in memory, retries transient failures with bounded exponential backoff, and uses a keepalive flush for page exit.
+
+Metadata is privacy-filtered. Passwords, tokens, secrets, email, chat/private messages, dialogue, player-entered text, raw exceptions, stack traces, and precise location are not sent.
+
+### Event taxonomy and coverage
+
+| journey/system | step key | action keys | important metadata | result coverage |
+| --- | --- | --- | --- | --- |
+| App/session | `app_launch`, `session_end` | `session_started`, `ended` | session, version, build, duration | start and exit |
+| Main menu | `main_menu` | `viewed` | local-save presence | viewed |
+| Game entry | `gameplay` | `started` | campaign/free survey, resumed, mission, input | start/resume |
+| Mission funnel | `mission_01` … `mission_05`, `operation_complete` | `mission_started`, `objective_completed`, `mission_completed`, `campaign_completed` | mission/objective IDs, duration, distance | progress and success |
+| Radar | current mission or `free_survey` | `radar_scan_started`, `radar_scan_completed` | power, returns, coherent returns | start/success/empty result |
+| Drilling/samples | current mission or `free_survey` | `drill_started`, `drill_aborted`, `sample_secured` | target/sample type, depth, duration, rare flag | start/success/abort |
+| Relay progression | current mission or `free_survey` | `relay_deployed` | relay count, elevation | success |
+| Station story beat | current mission | `station_data_recovered` | mission | success |
+| Damage/recovery | current mission or `free_survey` | `damage_taken`, `chassis_righted`, `recovery_triggered` | source, amount, hull | failure/recovery |
+| Codex | `codex` | `entry_unlocked` | stable entry ID, mission | reward/progression |
+| Menus | `menus`, `mission_briefing` | `opened`, `closed`, `acknowledged` | panel and return state | navigation |
+| Settings/accessibility | `settings_menu` | `setting_changed` | stable setting key, value/index | changes |
+| Saving | `cloud_save` | `synced`, `restored`, `sync_failed`, `conflict_detected`, `conflict_resolved` | version, size, safe error category, choice | success/failure/recovery |
+| Performance | `performance` | `sampled` | FPS, quality, viewport, mission, input | periodic health |
+| Errors | `errors` | `runtime_error`, `boot_failed` | phase and error class only | failure |
+
+Combat, economy, purchases, multiplayer, and standalone achievements do not exist in this game and therefore have no emitted events. Missions provide the quest/progression coverage.
+
+## Tests
+
+Run:
+
+```bash
+npm test
+```
+
+The Node test suite covers:
+
+- optional/disabled behavior;
+- install creation, desktop launch IDs, validation, recreation, denial, and offline grace;
+- production and consent gates;
+- event context, sensitive-field removal, duplicate prevention, and provider failure;
+- save encoding, decoded-byte checksum verification, upload fields, remote restore, and 409 resolution;
+- exact upstream routes and bearer placement;
+- server-only file blocking, path traversal, origin checks, field allowlists, and disabled feature routes.
+
+## Known limits
+
+- Cloud saves are unavailable to guest installs because Glitch requires a login-backed install.
+- Event retries are memory-only. Closing an offline tab can discard unsent analytics, but never game progress.
+- The in-process rate limiter is per Node instance; a multi-instance deployment should add a shared edge or Redis-backed limit.
+- This integration implements Glitch behavior analytics only. Google Analytics and Microsoft Clarity IDs were not provided and are not installed.
+- Dashboard funnel definitions are administrator actions and are not created from the shipped client.

--- a/docs/ONLINE_SERVICES.md
+++ b/docs/ONLINE_SERVICES.md
@@ -89,7 +89,8 @@ Cloud saves require a login-backed install with a Glitch `user_id`. Guest player
 - Matching checksums are deduplicated.
 - A remote-only save is restored locally after its checksum is verified.
 - A local-only or locally newer save uploads in the background.
-- A 409 conflict opens a player choice between `keep_server` and `use_client`, then calls the documented resolve endpoint. No conflict is overwritten silently.
+- When Glitch cloud saves are available, the cloud copy is authoritative for ambiguous divergence. The verified cloud payload replaces the local copy automatically without a player prompt.
+- A 409 upload conflict automatically calls the documented resolve endpoint with `keep_server`, downloads and checksum-verifies the winning cloud record, then replaces the local copy.
 - A blocked, failed, or offline provider leaves the local save intact and never pauses gameplay.
 
 ## Behavior analytics contract
@@ -139,7 +140,7 @@ The Node test suite covers:
 - install creation, desktop launch IDs, validation, recreation, denial, and offline grace;
 - automatic analytics startup whenever Glitch is enabled;
 - event context, sensitive-field removal, duplicate prevention, and provider failure;
-- save encoding, decoded-byte checksum verification, upload fields, remote restore, and 409 resolution;
+- save encoding, decoded-byte checksum verification, upload fields, automatic cloud-authoritative restore, and 409 resolution;
 - exact upstream routes and bearer placement;
 - server-only file blocking, path traversal, origin checks, field allowlists, and disabled feature routes.
 

--- a/index.html
+++ b/index.html
@@ -79,19 +79,6 @@
 </div>
 
 <!-- ============ ONLINE SERVICES ============ -->
-<div id="analyticsConsent" class="overlay choice hidden" role="dialog" aria-modal="true" aria-labelledby="analyticsTitle">
-  <div class="choice-card">
-    <div class="card-kicker">PRIVACY</div>
-    <h2 id="analyticsTitle">HELP IMPROVE REGOLITH?</h2>
-    <p>Share anonymous play events such as mission progress, menu use, performance, and errors. We do not send passwords, private text, or precise location.</p>
-    <p class="choice-note">Your choice does not affect gameplay or cloud saves. You can change it later under Systems.</p>
-    <div class="choice-actions">
-      <button class="btn ghost" id="analyticsDecline">NOT NOW</button>
-      <button class="btn primary" id="analyticsAllow">ALLOW</button>
-    </div>
-  </div>
-</div>
-
 <div id="cloudConflict" class="overlay choice hidden" role="dialog" aria-modal="true" aria-labelledby="cloudConflictTitle">
   <div class="choice-card">
     <div class="card-kicker">CLOUD SAVE</div>

--- a/index.html
+++ b/index.html
@@ -11,6 +11,7 @@
      returning player keeps the old layout for ten minutes after a deploy.
      Bump this whenever styles.css changes in a way players must see. -->
 <link rel="stylesheet" href="src/ui/styles.css?v=4" />
+<script src="runtime-config.js"></script>
 <script type="importmap">
 {
   "imports": {
@@ -61,6 +62,7 @@
         <button class="btn ghost" id="btnSettings">SYSTEMS</button>
       </div>
       <p class="hint">WebGL2 · GPU accelerated · headphones recommended</p>
+      <p class="backend-status hidden" id="backendStatus" role="status"></p>
     </div>
     <div class="menu-right">
       <div class="dossier">
@@ -72,6 +74,44 @@
         <div class="dossier-row"><span>LAST CONTACT</span><b>D+214</b></div>
         <div class="dossier-row alert"><span>STATUS</span><b>SILENT</b></div>
       </div>
+    </div>
+  </div>
+</div>
+
+<!-- ============ ONLINE SERVICES ============ -->
+<div id="analyticsConsent" class="overlay choice hidden" role="dialog" aria-modal="true" aria-labelledby="analyticsTitle">
+  <div class="choice-card">
+    <div class="card-kicker">PRIVACY</div>
+    <h2 id="analyticsTitle">HELP IMPROVE REGOLITH?</h2>
+    <p>Share anonymous play events such as mission progress, menu use, performance, and errors. We do not send passwords, private text, or precise location.</p>
+    <p class="choice-note">Your choice does not affect gameplay or cloud saves. You can change it later under Systems.</p>
+    <div class="choice-actions">
+      <button class="btn ghost" id="analyticsDecline">NOT NOW</button>
+      <button class="btn primary" id="analyticsAllow">ALLOW</button>
+    </div>
+  </div>
+</div>
+
+<div id="cloudConflict" class="overlay choice hidden" role="dialog" aria-modal="true" aria-labelledby="cloudConflictTitle">
+  <div class="choice-card">
+    <div class="card-kicker">CLOUD SAVE</div>
+    <h2 id="cloudConflictTitle">CHOOSE YOUR PROGRESS</h2>
+    <p>Progress on this device and in the cloud changed separately. Choose which copy to keep. The other copy will not replace it automatically.</p>
+    <p class="choice-note" id="cloudConflictDetail">Your local save remains safe until you choose.</p>
+    <div class="choice-actions">
+      <button class="btn ghost" id="cloudUseServer">USE CLOUD SAVE</button>
+      <button class="btn primary" id="cloudUseClient">KEEP THIS DEVICE</button>
+    </div>
+  </div>
+</div>
+
+<div id="accessDenied" class="overlay choice hidden" role="alertdialog" aria-modal="true" aria-labelledby="accessDeniedTitle">
+  <div class="choice-card">
+    <div class="card-kicker alert-text">CONNECTION REQUIRED</div>
+    <h2 id="accessDeniedTitle">ACCESS COULD NOT BE VERIFIED</h2>
+    <p id="accessDeniedMessage">Your local save is safe. Check your connection and try again.</p>
+    <div class="choice-actions">
+      <button class="btn primary" id="accessRetry">TRY AGAIN</button>
     </div>
   </div>
 </div>

--- a/index.html
+++ b/index.html
@@ -79,19 +79,6 @@
 </div>
 
 <!-- ============ ONLINE SERVICES ============ -->
-<div id="cloudConflict" class="overlay choice hidden" role="dialog" aria-modal="true" aria-labelledby="cloudConflictTitle">
-  <div class="choice-card">
-    <div class="card-kicker">CLOUD SAVE</div>
-    <h2 id="cloudConflictTitle">CHOOSE YOUR PROGRESS</h2>
-    <p>Progress on this device and in the cloud changed separately. Choose which copy to keep. The other copy will not replace it automatically.</p>
-    <p class="choice-note" id="cloudConflictDetail">Your local save remains safe until you choose.</p>
-    <div class="choice-actions">
-      <button class="btn ghost" id="cloudUseServer">USE CLOUD SAVE</button>
-      <button class="btn primary" id="cloudUseClient">KEEP THIS DEVICE</button>
-    </div>
-  </div>
-</div>
-
 <div id="accessDenied" class="overlay choice hidden" role="alertdialog" aria-modal="true" aria-labelledby="accessDeniedTitle">
   <div class="choice-card">
     <div class="card-kicker alert-text">CONNECTION REQUIRED</div>

--- a/package.json
+++ b/package.json
@@ -1,12 +1,14 @@
 {
   "name": "regolith-anaxagoras",
-  "version": "1.0.0",
+  "version": "1.1.1",
   "private": true,
   "description": "REGOLITH — The Silence at Anaxagoras. A GPU-rendered 3D lunar rover exploration game.",
   "type": "module",
   "scripts": {
     "start": "node server.js",
-    "dev": "node server.js 5173"
+    "dev": "node server.js 5173",
+    "test": "node --test",
+    "deploy:glitch": "node scripts/deploy-glitch.mjs"
   },
   "engines": { "node": ">=18" }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "regolith-anaxagoras",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "private": true,
   "description": "REGOLITH — The Silence at Anaxagoras. A GPU-rendered 3D lunar rover exploration game.",
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "regolith-anaxagoras",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "private": true,
   "description": "REGOLITH — The Silence at Anaxagoras. A GPU-rendered 3D lunar rover exploration game.",
   "type": "module",

--- a/runtime-config.js
+++ b/runtime-config.js
@@ -8,8 +8,7 @@ window.REGOLITH_RUNTIME_CONFIG = Object.freeze({
     apiOrigin: '',
     cloudSavesEnabled: false,
     analyticsEnabled: false,
-    analyticsTestMode: false,
-    gameVersion: '1.1.1',
+    gameVersion: '1.1.2',
     buildType: 'production'
   }
 });

--- a/runtime-config.js
+++ b/runtime-config.js
@@ -1,0 +1,15 @@
+/* Static-hosting default. The Node server replaces this response at runtime
+   when the optional Glitch backend is enabled. Never put tokens in this file. */
+window.REGOLITH_RUNTIME_CONFIG = Object.freeze({
+  glitch: {
+    enabled: false,
+    titleId: '6bd2c447-1770-441b-b94b-bceed5e81e87',
+    environment: 'development',
+    apiOrigin: '',
+    cloudSavesEnabled: false,
+    analyticsEnabled: false,
+    analyticsTestMode: false,
+    gameVersion: '1.1.1',
+    buildType: 'production'
+  }
+});

--- a/runtime-config.js
+++ b/runtime-config.js
@@ -8,7 +8,7 @@ window.REGOLITH_RUNTIME_CONFIG = Object.freeze({
     apiOrigin: '',
     cloudSavesEnabled: false,
     analyticsEnabled: false,
-    gameVersion: '1.1.2',
+    gameVersion: '1.1.3',
     buildType: 'production'
   }
 });

--- a/scripts/deploy-glitch.mjs
+++ b/scripts/deploy-glitch.mjs
@@ -70,8 +70,7 @@ async function run() {
     GLITCH_BACKEND_ENABLED: '1',
     GLITCH_TITLE_TOKEN: titleToken,
     NODE_ENV: 'production',
-    GLITCH_CLOUD_SAVES_ENABLED: '1',
-    GLITCH_ANALYTICS_ENABLED: '1'
+    GLITCH_CLOUD_SAVES_ENABLED: '1'
   }));
 
   const zipped = spawnSync('zip', ['-q', '-r', zipPath, '.'], { cwd: stage, stdio: 'inherit' });

--- a/scripts/deploy-glitch.mjs
+++ b/scripts/deploy-glitch.mjs
@@ -1,0 +1,154 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { spawnSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+
+const API = 'https://api.glitch.fun/api';
+const TITLE_ID = '6bd2c447-1770-441b-b94b-bceed5e81e87';
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const deployToken = String(process.env.GLITCH_DISTRIBUTION_TOKEN || '').trim();
+const titleToken = String(process.env.GLITCH_TITLE_TOKEN || '').trim();
+const activate = process.env.GLITCH_ACTIVATE !== '0';
+
+if (!deployToken.startsWith('gl_deploy_')) throw new Error('GLITCH_DISTRIBUTION_TOKEN is missing or invalid.');
+if (!titleToken) throw new Error('GLITCH_TITLE_TOKEN is required for the deployed server.');
+
+const pkg = JSON.parse(fs.readFileSync(path.join(ROOT, 'package.json'), 'utf8'));
+const version = String(process.env.GLITCH_VERSION || pkg.version);
+if (version.length > 20) throw new Error('Deployment version must be 20 characters or fewer.');
+
+const stageRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'regolith-glitch-'));
+const stage = path.join(stageRoot, 'build');
+const zipPath = path.join(stageRoot, `regolith-${version}.zip`);
+
+function copy(relative) {
+  const source = path.join(ROOT, relative);
+  const destination = path.join(stage, relative);
+  fs.mkdirSync(path.dirname(destination), { recursive: true });
+  fs.cpSync(source, destination, { recursive: true });
+}
+
+function authHeaders(json = true) {
+  return {
+    Authorization: `Bearer ${deployToken}`,
+    Accept: 'application/json',
+    ...(json ? { 'Content-Type': 'application/json' } : {})
+  };
+}
+
+async function api(pathname, { method = 'GET', body } = {}) {
+  const response = await fetch(`${API}${pathname}`, {
+    method,
+    headers: authHeaders(body !== undefined),
+    body: body === undefined ? undefined : JSON.stringify(body)
+  });
+  const text = await response.text();
+  let data = {};
+  if (text) {
+    try { data = JSON.parse(text); } catch { data = { message: text.slice(0, 500) }; }
+  }
+  if (!response.ok) {
+    const message = data.message || data.error || data.code || `HTTP ${response.status}`;
+    throw new Error(`Glitch deployment request failed: ${message}`);
+  }
+  return data;
+}
+
+function sleep(ms) { return new Promise(resolve => setTimeout(resolve, ms)); }
+
+async function run() {
+  fs.mkdirSync(stage, { recursive: true });
+  for (const item of [
+    'Dockerfile', 'index.html', 'runtime-config.js', 'package.json', 'server.js',
+    'backend/glitch-proxy.js', 'src', 'vendor', 'assets'
+  ]) copy(item);
+
+  // This ignored file exists only in the temporary deployment artifact. The
+  // static server cannot serve /backend/*, and the deploy token is never added.
+  fs.writeFileSync(path.join(stage, 'backend', 'runtime-secrets.json'), JSON.stringify({
+    GLITCH_BACKEND_ENABLED: '1',
+    GLITCH_TITLE_TOKEN: titleToken,
+    NODE_ENV: 'production',
+    GLITCH_CLOUD_SAVES_ENABLED: '1',
+    GLITCH_ANALYTICS_ENABLED: '1'
+  }));
+
+  const zipped = spawnSync('zip', ['-q', '-r', zipPath, '.'], { cwd: stage, stdio: 'inherit' });
+  if (zipped.status !== 0) throw new Error('Could not create the deployment ZIP.');
+  const file = fs.readFileSync(zipPath);
+  console.log(`Packaged Regolith ${version} (${file.length} bytes).`);
+
+  const initiated = await api(`/titles/${TITLE_ID}/deployments/multipart/initiate`, {
+    method: 'POST', body: {}
+  });
+  if (!initiated.file_path) throw new Error('Glitch did not return a deployment file path.');
+
+  if (initiated.is_local) {
+    const upload = await fetch(initiated.upload_url, { method: 'PUT', body: file });
+    if (!upload.ok) throw new Error(`Local deployment upload failed (${upload.status}).`);
+  } else {
+    if (!initiated.upload_id) throw new Error('Glitch did not return a multipart upload ID.');
+    const partSize = 8 * 1024 * 1024;
+    const partCount = Math.ceil(file.length / partSize);
+    const partNumbers = Array.from({ length: partCount }, (_, index) => index + 1);
+    const signed = await api(`/titles/${TITLE_ID}/deployments/multipart/urls`, {
+      method: 'POST',
+      body: { upload_id: initiated.upload_id, file_path: initiated.file_path, part_numbers: partNumbers }
+    });
+    const parts = [];
+    for (const partNumber of partNumbers) {
+      const start = (partNumber - 1) * partSize;
+      const end = Math.min(file.length, start + partSize);
+      const upload = await fetch(signed.urls[String(partNumber)], {
+        method: 'PUT', body: file.subarray(start, end)
+      });
+      if (!upload.ok) throw new Error(`Deployment part ${partNumber} failed (${upload.status}).`);
+      const etag = upload.headers.get('etag');
+      if (!etag) throw new Error(`Deployment part ${partNumber} did not return an ETag.`);
+      parts.push({ PartNumber: partNumber, ETag: etag });
+      console.log(`Uploaded part ${partNumber}/${partCount}.`);
+    }
+    await api(`/titles/${TITLE_ID}/deployments/multipart/complete`, {
+      method: 'POST',
+      body: { upload_id: initiated.upload_id, file_path: initiated.file_path, parts }
+    });
+  }
+
+  const confirmedResponse = await api(`/titles/${TITLE_ID}/deployments/confirm`, {
+    method: 'POST',
+    body: {
+      file_path: initiated.file_path,
+      version_string: version,
+      build_type: 'production',
+      deployment_type: 'node',
+      entry_point: 'server.js'
+    }
+  });
+  const confirmed = confirmedResponse.data || confirmedResponse;
+  if (!confirmed.id) throw new Error('Glitch did not return a build ID.');
+  console.log(`Build ${confirmed.id} confirmed with status ${confirmed.status}.`);
+
+  let build = confirmed;
+  for (let attempt = 0; attempt < 120 && build.status === 'processing'; attempt++) {
+    await sleep(5000);
+    const deployments = await api(`/titles/${TITLE_ID}/deployments`);
+    const records = Array.isArray(deployments.data) ? deployments.data : [];
+    build = records.find(record => record.id === confirmed.id) || build;
+    if ((attempt + 1) % 6 === 0) console.log(`Build is still processing (${(attempt + 1) * 5}s).`);
+  }
+
+  if (build.status === 'failed') throw new Error(`Build processing failed: ${build.error_log || 'no error log returned'}`);
+  if (build.status === 'processing') throw new Error('Build processing did not finish within 10 minutes.');
+  if (activate && build.status !== 'ready') {
+    const activatedResponse = await api(`/titles/${TITLE_ID}/deployments/${confirmed.id}/status`, {
+      method: 'PUT', body: { status: 'ready' }
+    });
+    build = activatedResponse.data || activatedResponse;
+  }
+  console.log(`Deployment complete: build ${build.id}, status ${build.status}.`);
+  if (build.cdn_url) console.log(`CDN: ${build.cdn_url}`);
+}
+
+try { await run(); }
+finally { fs.rmSync(stageRoot, { recursive: true, force: true }); }

--- a/server.js
+++ b/server.js
@@ -71,7 +71,7 @@ function runtimeConfig(config) {
       apiOrigin: config.apiOrigin,
       cloudSavesEnabled: config.enabled && config.cloudSavesEnabled,
       analyticsEnabled: config.enabled && config.analyticsEnabled,
-      gameVersion: '1.1.2',
+      gameVersion: '1.1.3',
       buildType: 'production'
     }
   };

--- a/server.js
+++ b/server.js
@@ -1,12 +1,13 @@
-/* Zero-dependency static server for REGOLITH.
+/* Zero-dependency static server and optional Glitch proxy for REGOLITH.
    node server.js [port]                                     */
 import http from 'node:http';
 import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { createGlitchProxy, GLITCH_API_BASE_URL, GLITCH_TITLE_ID } from './backend/glitch-proxy.js';
 
 const ROOT = path.dirname(fileURLToPath(import.meta.url));
-const PORT = Number(process.argv[2]) || 5173;
+const DEFAULT_PORT = 5173;
 
 const MIME = {
   '.html': 'text/html; charset=utf-8',
@@ -25,8 +26,97 @@ const MIME = {
 const SHOTS = process.argv.includes('--shots');
 const SHOT_DIR = process.env.SHOT_DIR || path.join(ROOT, '.shots');
 
-const server = http.createServer((req, res) => {
+function readServerSecrets(root) {
+  const file = path.join(root, 'backend', 'runtime-secrets.json');
+  try {
+    const parsed = JSON.parse(fs.readFileSync(file, 'utf8'));
+    return parsed && typeof parsed === 'object' && !Array.isArray(parsed) ? parsed : {};
+  } catch { return {}; }
+}
+
+function truthy(value) { return ['1', 'true', 'yes', 'on'].includes(String(value || '').toLowerCase()); }
+
+export function loadServerConfig(env = process.env, root = ROOT) {
+  const values = { ...readServerSecrets(root), ...env };
+  const requested = truthy(values.GLITCH_BACKEND_ENABLED);
+  const titleToken = String(values.GLITCH_TITLE_TOKEN || '').trim();
+  const enabled = requested && titleToken.length > 0;
+  const environment = values.NODE_ENV === 'production' ? 'production' : 'development';
+  const analyticsTestMode = truthy(values.GLITCH_ANALYTICS_TEST_MODE);
+  return {
+    port: Number(values.PORT || process.argv[2]) || DEFAULT_PORT,
+    glitch: {
+      enabled,
+      requested,
+      apiBaseUrl: String(values.GLITCH_API_BASE_URL || GLITCH_API_BASE_URL).replace(/\/$/, ''),
+      titleId: GLITCH_TITLE_ID,
+      titleToken,
+      environment,
+      apiOrigin: String(values.REGOLITH_PUBLIC_API_ORIGIN || ''),
+      cloudSavesEnabled: values.GLITCH_CLOUD_SAVES_ENABLED !== '0',
+      analyticsEnabled: values.GLITCH_ANALYTICS_ENABLED !== '0' &&
+        (environment === 'production' || analyticsTestMode),
+      analyticsTestMode,
+      allowedOrigins: String(values.REGOLITH_ALLOWED_ORIGINS || '')
+        .split(',').map(v => v.trim()).filter(Boolean),
+      requestTimeoutMs: Math.max(1000, Number(values.GLITCH_REQUEST_TIMEOUT_MS) || 10_000),
+      rateLimitPerMinute: Math.max(10, Number(values.GLITCH_RATE_LIMIT_PER_MINUTE) || 180)
+    }
+  };
+}
+
+function runtimeConfig(config) {
+  const publicConfig = {
+    glitch: {
+      enabled: config.enabled,
+      titleId: config.titleId,
+      environment: config.environment,
+      apiOrigin: config.apiOrigin,
+      cloudSavesEnabled: config.enabled && config.cloudSavesEnabled,
+      analyticsEnabled: config.enabled && config.analyticsEnabled,
+      analyticsTestMode: config.analyticsTestMode,
+      gameVersion: '1.1.1',
+      buildType: 'production'
+    }
+  };
+  return `window.REGOLITH_RUNTIME_CONFIG = Object.freeze(${JSON.stringify(publicConfig)});\n`;
+}
+
+function securityHeaders(contentType, apiOrigin = '') {
+  let connect = "'self'";
+  try { if (apiOrigin) connect += ` ${new URL(apiOrigin).origin}`; } catch { /* invalid values fail closed */ }
+  return {
+    'X-Content-Type-Options': 'nosniff',
+    'Referrer-Policy': 'strict-origin-when-cross-origin',
+    'Permissions-Policy': 'camera=(), microphone=(), geolocation=(), payment=()',
+    'Cross-Origin-Resource-Policy': 'same-origin',
+    'Content-Security-Policy': `default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; media-src 'self' blob:; connect-src ${connect}; object-src 'none'; base-uri 'none'; frame-ancestors 'self' https://*.glitch.fun`,
+    ...(contentType ? { 'Content-Type': contentType } : {})
+  };
+}
+
+function isPublicPath(rel) {
+  if (rel === '/index.html' || rel === '/runtime-config.js') return true;
+  return ['/src/', '/vendor/', '/assets/'].some(prefix => rel.startsWith(prefix));
+}
+
+function isLoopback(address) {
+  return address === '127.0.0.1' || address === '::1' || address === '::ffff:127.0.0.1';
+}
+
+export function createRegolithServer({ root = ROOT, env = process.env, fetchImpl = globalThis.fetch } = {}) {
+  const config = loadServerConfig(env, root);
+  if (config.glitch.requested && !config.glitch.enabled) {
+    throw new Error('GLITCH_BACKEND_ENABLED requires GLITCH_TITLE_TOKEN.');
+  }
+  const handleGlitch = createGlitchProxy({ config: config.glitch, fetchImpl });
+
+  const server = http.createServer(async (req, res) => {
+    const url = new URL(req.url, 'http://local');
+    if (await handleGlitch(req, res, url)) return;
+
   if (SHOTS && req.method === 'POST' && req.url.startsWith('/__shot')) {
+    if (!isLoopback(req.socket.remoteAddress)) { res.writeHead(403).end('Forbidden'); return; }
     let body = '';
     req.on('data', (c) => { body += c; if (body.length > 400e6) req.destroy(); });
     req.on('end', () => {
@@ -43,26 +133,55 @@ const server = http.createServer((req, res) => {
     return;
   }
 
-  let rel = decodeURIComponent(req.url.split('?')[0]);
+  if (req.method !== 'GET' && req.method !== 'HEAD') {
+    res.writeHead(405, { Allow: 'GET, HEAD', ...securityHeaders('text/plain; charset=utf-8', config.glitch.apiOrigin) }).end('Method Not Allowed');
+    return;
+  }
+
+  let rel;
+  try { rel = decodeURIComponent(url.pathname); }
+  catch { res.writeHead(400, securityHeaders('text/plain; charset=utf-8', config.glitch.apiOrigin)).end('Bad Request'); return; }
   if (rel === '/') rel = '/index.html';
-  const file = path.join(ROOT, path.normalize(rel).replace(/^([/\\])+/, ''));
-  if (!file.startsWith(ROOT)) { res.writeHead(403).end('Forbidden'); return; }
+  rel = path.posix.normalize(rel.replaceAll('\\', '/'));
+  if (!isPublicPath(rel)) {
+    res.writeHead(404, securityHeaders('text/plain; charset=utf-8', config.glitch.apiOrigin)).end('404 — not found');
+    return;
+  }
+  if (rel === '/runtime-config.js') {
+    const data = Buffer.from(runtimeConfig(config.glitch));
+    res.writeHead(200, {
+      ...securityHeaders('text/javascript; charset=utf-8', config.glitch.apiOrigin),
+      'Content-Length': data.length,
+      'Cache-Control': 'no-store'
+    });
+    if (req.method === 'HEAD') res.end(); else res.end(data);
+    return;
+  }
+  const file = path.join(root, path.normalize(rel).replace(/^([/\\])+/, ''));
+  if (file !== root && !file.startsWith(root + path.sep)) { res.writeHead(403).end('Forbidden'); return; }
 
   fs.stat(file, (err, st) => {
     if (err || !st.isFile()) { res.writeHead(404, { 'Content-Type': 'text/plain' }).end('404 — not found'); return; }
     const ext = path.extname(file).toLowerCase();
     res.writeHead(200, {
-      'Content-Type': MIME[ext] || 'application/octet-stream',
+      ...securityHeaders(MIME[ext] || 'application/octet-stream', config.glitch.apiOrigin),
       'Content-Length': st.size,
       'Cache-Control': 'no-cache',
       // COOP/COEP left off deliberately: nothing here needs SharedArrayBuffer.
-      'X-Content-Type-Options': 'nosniff'
     });
-    fs.createReadStream(file).pipe(res);
+    if (req.method === 'HEAD') res.end(); else fs.createReadStream(file).pipe(res);
   });
-});
+  });
 
-server.listen(PORT, () => {
-  console.log(`\n  REGOLITH — The Silence at Anaxagoras`);
-  console.log(`  running at  http://localhost:${PORT}\n`);
-});
+  return { server, config };
+}
+
+const invokedDirectly = process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url);
+if (invokedDirectly) {
+  const { server, config } = createRegolithServer();
+  server.listen(config.port, () => {
+    console.log(`\n  REGOLITH — The Silence at Anaxagoras`);
+    console.log(`  running at  http://localhost:${config.port}`);
+    console.log(`  online services  ${config.glitch.enabled ? 'enabled' : 'disabled'}\n`);
+  });
+}

--- a/server.js
+++ b/server.js
@@ -42,7 +42,6 @@ export function loadServerConfig(env = process.env, root = ROOT) {
   const titleToken = String(values.GLITCH_TITLE_TOKEN || '').trim();
   const enabled = requested && titleToken.length > 0;
   const environment = values.NODE_ENV === 'production' ? 'production' : 'development';
-  const analyticsTestMode = truthy(values.GLITCH_ANALYTICS_TEST_MODE);
   return {
     port: Number(values.PORT || process.argv[2]) || DEFAULT_PORT,
     glitch: {
@@ -54,9 +53,7 @@ export function loadServerConfig(env = process.env, root = ROOT) {
       environment,
       apiOrigin: String(values.REGOLITH_PUBLIC_API_ORIGIN || ''),
       cloudSavesEnabled: values.GLITCH_CLOUD_SAVES_ENABLED !== '0',
-      analyticsEnabled: values.GLITCH_ANALYTICS_ENABLED !== '0' &&
-        (environment === 'production' || analyticsTestMode),
-      analyticsTestMode,
+      analyticsEnabled: enabled,
       allowedOrigins: String(values.REGOLITH_ALLOWED_ORIGINS || '')
         .split(',').map(v => v.trim()).filter(Boolean),
       requestTimeoutMs: Math.max(1000, Number(values.GLITCH_REQUEST_TIMEOUT_MS) || 10_000),
@@ -74,8 +71,7 @@ function runtimeConfig(config) {
       apiOrigin: config.apiOrigin,
       cloudSavesEnabled: config.enabled && config.cloudSavesEnabled,
       analyticsEnabled: config.enabled && config.analyticsEnabled,
-      analyticsTestMode: config.analyticsTestMode,
-      gameVersion: '1.1.1',
+      gameVersion: '1.1.2',
       buildType: 'production'
     }
   };

--- a/src/core/save.js
+++ b/src/core/save.js
@@ -1,15 +1,47 @@
 const KEY = 'regolith.anaxagoras.v1';
+const META_KEY = KEY + '.meta';
+let syncHandler = null;
+
+function readMeta() {
+  try { return JSON.parse(localStorage.getItem(META_KEY) || 'null') || {}; }
+  catch { return {}; }
+}
+
+function writeMeta(meta) {
+  try { localStorage.setItem(META_KEY, JSON.stringify(meta)); } catch { /* private mode */ }
+}
 
 export const Save = {
   read() {
     try { return JSON.parse(localStorage.getItem(KEY) || 'null'); }
     catch { return null; }
   },
-  write(data) {
-    try { localStorage.setItem(KEY, JSON.stringify(data)); return true; }
+  write(data, options = {}) {
+    try {
+      localStorage.setItem(KEY, JSON.stringify(data));
+      const meta = { ...readMeta(), updatedAt: options.updatedAt || new Date().toISOString() };
+      writeMeta(meta);
+      if (options.sync !== false && syncHandler) syncHandler(data, meta);
+      return true;
+    }
     catch { return false; }
   },
-  clear() { try { localStorage.removeItem(KEY); } catch { /* private mode */ } },
+  clear() {
+    try { localStorage.removeItem(KEY); localStorage.removeItem(META_KEY); } catch { /* private mode */ }
+  },
+  meta() { return readMeta(); },
+  markCloudSynced(version, checksum) {
+    writeMeta({ ...readMeta(), cloudVersion: version, cloudChecksum: checksum });
+  },
+  replaceFromCloud(data, record) {
+    const updatedAt = record.client_timestamp || record.updated_at || new Date().toISOString();
+    try {
+      localStorage.setItem(KEY, JSON.stringify(data));
+      writeMeta({ updatedAt, cloudVersion: record.version, cloudChecksum: record.checksum });
+      return true;
+    } catch { return false; }
+  },
+  setSyncHandler(handler) { syncHandler = typeof handler === 'function' ? handler : null; },
   settings() {
     try { return JSON.parse(localStorage.getItem(KEY + '.set') || 'null') || {}; }
     catch { return {}; }

--- a/src/game/gameplay.js
+++ b/src/game/gameplay.js
@@ -130,6 +130,14 @@ export class Game {
 
   log(text, kind) { this.hud.log(text, kind); }
 
+  event(step, action, metadata = {}, options = {}) {
+    try { this.telemetry?.track(step, action, metadata, options); } catch { /* analytics never affects play */ }
+  }
+
+  missionStep(index = this.missionIdx) {
+    return `mission_${String(index + 1).padStart(2, '0')}`;
+  }
+
   unlock(id) {
     if (this.unlocked.has(id)) return;
     const e = CODEX.find(c => c.id === id);
@@ -139,6 +147,7 @@ export class Game {
     this.log(`CODEX · ${e.title}`, 'good');
     this.audio.discovery();
     this.hud.flashDiscovery('CODEX UPDATED', e.title, e.meta);
+    this.event('codex', 'entry_unlocked', { entry_id: id, mission_index: this.missionIdx });
   }
 
   complete(objId) {
@@ -147,6 +156,10 @@ export class Game {
     this.audio.ui('ok');
     this.hud.missionDirty = true;
     const m = this.mission;
+    this.event(this.missionStep(), 'objective_completed', {
+      mission_index: this.missionIdx,
+      objective_id: objId
+    }, { dedupeKey: `objective:${this.missionIdx}:${objId}`, dedupeMs: 60_000 });
     if (m && m.objectives.every(o => this.objDone[o.id])) {
       setTimeout(() => this.advance(), 1400);
     }
@@ -162,12 +175,19 @@ export class Game {
   advance() {
     const done = this.mission;
     if (!done) return;
+    const completedIndex = this.missionIdx;
     this.missionIdx++;
     this.log(`${done.tag} COMPLETE — ${done.name}`, 'good');
     this.audio.discovery();
+    this.event(this.missionStep(completedIndex), 'mission_completed', {
+      mission_index: completedIndex,
+      play_duration_seconds: Math.round(this.met)
+    }, { dedupeKey: `mission-complete:${completedIndex}`, dedupeMs: 60_000 });
     if (this.mission) {
       this.hud.showCard(this.mission);
       this.hud.missionDirty = true;
+      this.event(this.missionStep(), 'mission_started', { mission_index: this.missionIdx },
+        { dedupeKey: `mission-start:${this.missionIdx}`, dedupeMs: 60_000 });
     } else {
       this.hud.showCard({
         tag: 'OPERATION ANAXAGORAS', name: 'TRANSMITTED',
@@ -175,6 +195,10 @@ export class Game {
         objectives: [{ id: '_', text: 'Free survey unlocked — the basin is yours' }]
       });
       this.freeRoam = true;
+      this.event('operation_complete', 'campaign_completed', {
+        play_duration_seconds: Math.round(this.met),
+        distance_meters: Math.round(this.rover.odo || 0)
+      }, { dedupeKey: 'campaign-completed', dedupeMs: 60_000 });
     }
     this.save();
   }
@@ -190,6 +214,10 @@ export class Game {
     this.scan.x = this.rover.pos.x; this.scan.z = this.rover.pos.z;
     this.audio.chirp();
     this.log('GPR SWEEP — 400 MHz, 78 m aperture');
+    this.event(this.mission ? this.missionStep() : 'free_survey', 'radar_scan_started', {
+      mission_index: this.missionIdx,
+      power_percent: Math.round(this.power)
+    });
     this.complete('scan');
   }
 
@@ -212,6 +240,11 @@ export class Game {
       this.log('NO RETURN — homogeneous regolith to 12 m');
     }
     this.hud.mapDirty = true;
+    this.event(this.mission ? this.missionStep() : 'free_survey', 'radar_scan_completed', {
+      mission_index: this.missionIdx,
+      returns_found: hits,
+      coherent_returns: deep
+    });
   }
 
   addMarker(a) {
@@ -269,6 +302,11 @@ export class Game {
     this.drill.active = true; this.drill.t = 0; this.drill.target = a;
     this.rover.drilling = true;
     this.log(a ? `DRILLING · TARGET AT ${a.depth.toFixed(1)} m` : 'DRILLING · BLIND CORE');
+    this.event(this.mission ? this.missionStep() : 'free_survey', 'drill_started', {
+      mission_index: this.missionIdx,
+      target_type: a?.type || 'blind',
+      target_depth_meters: a ? Number(a.depth.toFixed(1)) : null
+    });
   }
 
   _finishDrill() {
@@ -290,6 +328,13 @@ export class Game {
     this.audio.discovery();
     this.hud.flashDiscovery('SAMPLE SECURED', def.name, def.desc);
     this.log(`SAMPLE ${String(this.bay.length).padStart(2, '0')} · ${def.name}`, def.rare ? 'good' : null);
+    this.event(this.mission ? this.missionStep() : 'free_survey', 'sample_secured', {
+      mission_index: this.missionIdx,
+      sample_type: type,
+      rare: !!def.rare,
+      sample_bay_count: this.bay.length,
+      drill_duration_seconds: Number(this.drill.t.toFixed(1))
+    });
     // the excavation stays in the ground, right where the bit went in
     this.terrain.excavate(this.rover.armTarget.x, this.rover.armTarget.z, 1.4, 0.85);
   }
@@ -315,6 +360,11 @@ export class Game {
     this.dust.spawn(60, bx, this.terrain.heightAt(bx, bz), bz, 1.4, 0.6);
     this.audio.ui('ok'); this.audio.radio();
     this.log(`RELAY ${this.relaysPlaced}/3 DEPLOYED AT ${h.toFixed(0)} m`, 'good');
+    this.event(this.mission ? this.missionStep() : 'free_survey', 'relay_deployed', {
+      mission_index: this.missionIdx,
+      relay_count: this.relaysPlaced,
+      elevation_meters: Math.round(h)
+    });
     this.bump('relays');
     if (this.relaysPlaced >= 3) this.unlock('memo');
     this.hud.mapDirty = true;
@@ -364,6 +414,11 @@ export class Game {
       if (this.rover.vel.length() > 1.2) {
         this.drill.active = false; this.rover.drilling = false;
         this.log('DRILL CYCLE ABORTED — CHASSIS MOVED', 'warn'); this.audio.ui('bad');
+        this.event(this.mission ? this.missionStep() : 'free_survey', 'drill_aborted', {
+          mission_index: this.missionIdx,
+          reason: 'chassis_moved',
+          elapsed_seconds: Number(this.drill.t.toFixed(1))
+        });
       } else if (this.drill.t >= OPS.drillTime) {
         this.drill.active = false; this.rover.drilling = false;
         this._finishDrill();
@@ -467,6 +522,8 @@ export class Game {
         this.unlock('log6'); this.unlock('log11');
         this.log('LOCAL STORE RECOVERED — 3 LOG FRAGMENTS', 'good');
         this.audio.radio();
+        this.event(this.missionStep(), 'station_data_recovered', { mission_index: this.missionIdx },
+          { dedupeKey: 'station-data-recovered', dedupeMs: 60_000 });
       }
     } else this.interact.t = 0;
     this.hud.interactProgress = key ? this.interact.t / 1.6 : 0;
@@ -486,6 +543,10 @@ export class Game {
           this.dust.spawn(90, this.rover.pos.x, this.rover.pos.y - 1, this.rover.pos.z, 2.2, 1.6);
           this.audio.thud(1.4);
           this.log('CHASSIS RIGHTED — 4 % INTEGRITY LOST', 'warn');
+          this.event(this.mission ? this.missionStep() : 'free_survey', 'chassis_righted', {
+            mission_index: this.missionIdx,
+            hull_percent: Math.round(this.hull)
+          });
         }
       }
     } else this.flipTimer = 0;
@@ -515,6 +576,12 @@ export class Game {
     this.hud.hit(clamp(amount / 12, 0.15, 1));
     this.audio.thud(clamp(amount / 6, 0.4, 2));
     if (amount > 4) this.log(`IMPACT — ${amount.toFixed(0)} % INTEGRITY${reason ? ' · ' + reason : ''}`, 'bad');
+    if (amount > 1) this.event(this.mission ? this.missionStep() : 'free_survey', 'damage_taken', {
+      mission_index: this.missionIdx,
+      amount_percent: Number(amount.toFixed(1)),
+      source: String(reason || 'impact').toLowerCase().replace(/[^a-z0-9]+/g, '_'),
+      hull_percent: Math.round(this.hull)
+    }, { dedupeMs: 1500 });
     if (this.hull <= 0) this.strand();
   }
 
@@ -524,6 +591,10 @@ export class Game {
     this.rover.placeAt(HOME.x - 9, HOME.z - 9, 2.2);
     this.power = Math.max(this.power, 35);
     this.audio.ui('bad');
+    this.event(this.mission ? this.missionStep() : 'free_survey', 'recovery_triggered', {
+      mission_index: this.missionIdx,
+      reason: 'critical_damage'
+    });
   }
 
   /* ============================================================

--- a/src/main.js
+++ b/src/main.js
@@ -34,10 +34,7 @@ const App = {
   elapsed: 0, sunAz: 4.35, paused: false
 };
 
-const backend = createBrowserBackend({
-  onStatus: showBackendStatus,
-  onConflict: promptCloudConflict
-});
+const backend = createBrowserBackend({ onStatus: showBackendStatus });
 App.backend = backend;
 
 function guessQuality() {
@@ -72,24 +69,6 @@ function showBackendStatus(message) {
   if (!el) return;
   el.textContent = message || '';
   el.classList.toggle('hidden', !message);
-}
-
-function promptCloudConflict(details = {}) {
-  const overlay = $('cloudConflict');
-  const detail = $('cloudConflictDetail');
-  if (details.serverVersion) detail.textContent =
-    `The cloud copy is version ${details.serverVersion}. Your local save remains safe until you choose.`;
-  overlay.classList.remove('hidden');
-  return new Promise((resolve) => {
-    const finish = (choice) => {
-      overlay.classList.add('hidden');
-      $('cloudUseServer').onclick = null;
-      $('cloudUseClient').onclick = null;
-      resolve(choice);
-    };
-    $('cloudUseServer').onclick = () => finish('keep_server');
-    $('cloudUseClient').onclick = () => finish('use_client');
-  });
 }
 
 /* Optional imagery. The game generates everything it needs, so the repo ships

--- a/src/main.js
+++ b/src/main.js
@@ -7,6 +7,7 @@ import { Engine, QUALITY } from './core/engine.js';
 import { Input } from './core/input.js';
 import { Audio } from './core/audio.js';
 import { Save } from './core/save.js';
+import { BackendAccessError, createBrowserBackend } from './services/backend.js';
 import { clamp, sstep, lerp } from './core/rng.js';
 import { bakeTerrain, Terrain, PLAYABLE_R } from './world/terrain.js';
 import { Sky } from './world/sky.js';
@@ -28,10 +29,16 @@ const App = {
     quality: guessQuality(), fov: 58, sens: 1.0, invertY: false,
     bloom: true, grain: 1.0, aberr: 1.0, stars: 1.0,
     volSfx: 0.8, volMusic: 0.5, music: true, tc: true, hudOn: true, autoCentre: 1,
-    hudScale: 1, realistic: false, comms: false
+    hudScale: 1, realistic: false, comms: false, analyticsConsent: null
   }, Save.settings()),
   elapsed: 0, sunAz: 4.35, paused: false
 };
+
+const backend = createBrowserBackend({
+  onStatus: showBackendStatus,
+  onConflict: promptCloudConflict
+});
+App.backend = backend;
 
 function guessQuality() {
   // deviceMemory is Chromium-only, so on Safari and Firefox the core count has
@@ -58,6 +65,45 @@ const bar = $('loadfill'), loadtext = $('loadtext');
 function progress(p, msg) {
   bar.style.width = (clamp(p, 0, 1) * 100).toFixed(1) + '%';
   if (msg) loadtext.textContent = msg;
+}
+
+function showBackendStatus(message) {
+  const el = $('backendStatus');
+  if (!el) return;
+  el.textContent = message || '';
+  el.classList.toggle('hidden', !message);
+}
+
+function promptCloudConflict(details = {}) {
+  const overlay = $('cloudConflict');
+  const detail = $('cloudConflictDetail');
+  if (details.serverVersion) detail.textContent =
+    `The cloud copy is version ${details.serverVersion}. Your local save remains safe until you choose.`;
+  overlay.classList.remove('hidden');
+  return new Promise((resolve) => {
+    const finish = (choice) => {
+      overlay.classList.add('hidden');
+      $('cloudUseServer').onclick = null;
+      $('cloudUseClient').onclick = null;
+      resolve(choice);
+    };
+    $('cloudUseServer').onclick = () => finish('keep_server');
+    $('cloudUseClient').onclick = () => finish('use_client');
+  });
+}
+
+function setAnalyticsChoice(granted) {
+  App.settings.analyticsConsent = granted;
+  Save.saveSettings(App.settings);
+  backend.setAnalyticsConsent(granted);
+  $('analyticsConsent').classList.add('hidden');
+  if (App.audio?.ready) App.audio.ui(granted ? 'ok' : 'tick');
+  if (App.audio) buildSettingsUI();
+}
+
+function maybeAskAnalyticsConsent() {
+  if (!backend.shouldAskForAnalyticsConsent || App.settings.analyticsConsent !== null) return;
+  $('analyticsConsent').classList.remove('hidden');
 }
 
 /* Optional imagery. The game generates everything it needs, so the repo ships
@@ -98,6 +144,12 @@ function loadTextures() {
 }
 
 async function boot() {
+  progress(0.005, 'verifying online services…');
+  await backend.initialize();
+  backend.setAnalyticsConsent(App.settings.analyticsConsent === true);
+  await backend.syncInitialSave(Save);
+  Save.setSyncHandler((data, meta) => backend.queueCloudSave(data, meta));
+
   progress(0.01, 'initialising telemetry link…');
 
   const engine = new Engine($('stage'), App.settings.quality);
@@ -164,7 +216,8 @@ async function boot() {
 
   const input = new Input($('stage'));
   const game = new Game({
-    terrain, rover, props, dust, sky, audio, hud, engine, rig, scene: engine.scene, input
+    terrain, rover, props, dust, sky, audio, hud, engine, rig, scene: engine.scene, input,
+    telemetry: backend
   });
   game.tc = App.settings.tc;
 
@@ -182,6 +235,7 @@ async function boot() {
   await new Promise(r => setTimeout(r, 260));
   $('boot').classList.add('hidden');
   showMenu();
+  maybeAskAnalyticsConsent();
   requestAnimationFrame(frame);
 }
 
@@ -202,6 +256,7 @@ function showMenu() {
      sled on the floor of <b>Anaxagoras</b> at seventy-three degrees north.<br><br>
      Survey the basin. Restore the relay chain. Find out what is under the floor —
      and why the dossier does not say what the station was <em>for</em>.`;
+  backend.track('main_menu', 'viewed', { has_local_save: !!saved }, { dedupeMs: 5000 });
 }
 
 function startGame(freeRoam, loadSaved) {
@@ -228,6 +283,13 @@ function startGame(freeRoam, loadSaved) {
   App.input.showTouch(true);
   App.hud.log('MU-7 CASSIOPEIA — SYSTEMS NOMINAL', 'good');
   App.hud.log('SELENE DIRECTORATE · FAR-SIDE SURVEY DIVISION');
+  const mode = freeRoam ? 'free_survey' : 'campaign';
+  backend.startPlay(mode, resumed, {
+    mission_index: App.game.missionIdx,
+    input_method: inputMethod()
+  });
+  App.game.event(freeRoam ? 'free_survey' : `mission_${String(App.game.missionIdx + 1).padStart(2, '0')}`,
+    resumed ? 'resumed' : 'started', { input_method: inputMethod() });
 
   if (!resumed && !freeRoam) {
     setTimeout(() => {
@@ -252,11 +314,13 @@ function openPanel(id, state) {
   App.input.unlock();
   App.input.showTouch(false);
   App.audio.ui('tick');
+  backend.track('menus', 'opened', { panel: id, from_state: panelReturn });
 }
 function closePanels() {
   for (const id of ['pause', 'codex', 'help']) $(id).classList.add('hidden');
   if (panelReturn === ST.MENU) showMenu();
   else { App.state = ST.PLAY; App.input.lock(); App.input.showTouch(true); }
+  backend.track('menus', 'closed', { return_state: panelReturn });
 }
 
 function wireUI() {
@@ -270,6 +334,7 @@ function wireUI() {
   $('btnCodexFromPause').onclick = () => { $('pause').classList.add('hidden'); openPanel('codex', ST.CODEX); };
   $('btnAbort').onclick = () => {
     Save.write(App.game.save());
+    backend.endPlay('abort_to_menu', gameContext());
     for (const id of ['pause', 'codex', 'help']) $(id).classList.add('hidden');
     showMenu();
   };
@@ -277,10 +342,17 @@ function wireUI() {
     App.hud.hideCard();
     App.state = ST.PLAY; App.input.lock(); App.input.showTouch(true);
     App.audio.ui('ok');
+    backend.track('mission_briefing', 'acknowledged', { mission_index: App.game.missionIdx });
   };
   // one close path, so the ESC button and the Escape key cannot diverge
   document.querySelectorAll('[data-close]').forEach(b => b.onclick = closePanels);
-  addEventListener('beforeunload', () => { if (App.game && App.state >= ST.PLAY) Save.write(App.game.save()); });
+  $('analyticsDecline').onclick = () => setAnalyticsChoice(false);
+  $('analyticsAllow').onclick = () => setAnalyticsChoice(true);
+  $('accessRetry').onclick = () => location.reload();
+  addEventListener('beforeunload', () => {
+    if (App.game && App.state >= ST.PLAY) Save.write(App.game.save());
+    backend.endPlay('page_unload', gameContext());
+  });
 }
 
 /* ---------------- settings ---------------- */
@@ -288,10 +360,11 @@ function buildSettingsUI() {
   const body = $('settingsBody');
   const S = App.settings;
   const rows = [];
+  const settingKey = (label) => label.toLowerCase().replace(/[^a-z0-9]+/g, '_').replace(/^_|_$/g, '');
   const seg = (label, note, opts, get, set) => rows.push(
-    { type: 'seg', label, note, opts, get, set });
+    { type: 'seg', key: settingKey(label), label, note, opts, get, set });
   const rng = (label, note, min, max, step, get, set) => rows.push(
-    { type: 'rng', label, note, min, max, step, get, set });
+    { type: 'rng', key: settingKey(label), label, note, min, max, step, get, set });
 
   seg('RENDER QUALITY', 'clipmap, shadows, excavation grid, boulders, particles',
     ['LOW', 'MEDIUM', 'HIGH', 'ULTRA'],
@@ -335,6 +408,11 @@ function buildSettingsUI() {
     () => S.tc ? 1 : 0, (i) => { S.tc = !!i; App.game.tc = !!i; persist(); });
   seg('SCORE', 'generative, D minor, patient', ['OFF', 'ON'],
     () => S.music ? 1 : 0, (i) => { S.music = !!i; App.audio.setMusic(!!i); persist(); });
+  if (backend.analyticsAvailable) {
+    seg('USAGE ANALYTICS', 'anonymous mission, menu, performance, and error events', ['OFF', 'ON'],
+      () => S.analyticsConsent === true ? 1 : 0,
+      (i) => { S.analyticsConsent = !!i; backend.setAnalyticsConsent(!!i); persist(); });
+  }
   rng('FIELD OF VIEW', 'degrees', 42, 82, 1, () => S.fov, (v) => { S.fov = v; App.rig.fovScale = v / 58; persist(); });
   rng('LOOK SENSITIVITY', '', 0.25, 3, 0.05, () => S.sens, (v) => { S.sens = v; applySettings(); persist(); });
   rng('EFFECTS VOLUME', '', 0, 1, 0.05, () => S.volSfx, (v) => { S.volSfx = v; App.audio.setVolumes(v, S.volMusic); persist(); });
@@ -350,7 +428,12 @@ function buildSettingsUI() {
       const s = document.createElement('div'); s.className = 'seg';
       r.opts.forEach((o, i) => {
         const b = document.createElement('button'); b.textContent = o;
-        b.onclick = () => { r.set(i); [...s.children].forEach((c, j) => c.classList.toggle('on', j === i)); App.audio.ui('tick'); };
+        b.onclick = () => {
+          r.set(i);
+          [...s.children].forEach((c, j) => c.classList.toggle('on', j === i));
+          backend.track('settings_menu', 'setting_changed', { setting_key: r.key, option_index: i });
+          App.audio.ui('tick');
+        };
         s.appendChild(b);
       });
       [...s.children].forEach((c, j) => c.classList.toggle('on', j === r.get()));
@@ -363,6 +446,9 @@ function buildSettingsUI() {
       v.style.cssText = 'margin-left:10px;font-size:10px;color:#6fe3f5;min-width:34px;display:inline-block';
       v.textContent = (+r.get()).toFixed(r.step < 1 ? 2 : 0);
       i.oninput = () => { r.set(+i.value); v.textContent = (+i.value).toFixed(r.step < 1 ? 2 : 0); };
+      i.onchange = () => backend.track('settings_menu', 'setting_changed', {
+        setting_key: r.key, value: +i.value
+      }, { dedupeKey: `setting:${r.key}:${i.value}`, dedupeMs: 500 });
       wrap.appendChild(i); wrap.appendChild(v);
       d.appendChild(wrap);
     }
@@ -370,6 +456,23 @@ function buildSettingsUI() {
   }
 }
 function persist() { Save.saveSettings(App.settings); }
+
+function inputMethod() {
+  if (App.input?.touch?.active) return 'touch';
+  if (App.input?.pad !== null && App.input?.pad !== undefined) return 'gamepad';
+  return 'keyboard_mouse';
+}
+
+function gameContext() {
+  if (!App.game) return {};
+  return {
+    mission_index: App.game.missionIdx,
+    mission_complete: !App.game.mission,
+    play_duration_seconds: Math.round(App.game.met || 0),
+    distance_meters: Math.round(App.rover?.odo || 0),
+    input_method: inputMethod()
+  };
+}
 
 /* Save the frame that was just drawn. Photo mode hides the HUD already, so what
    lands on disk is what you framed. */
@@ -517,7 +620,20 @@ function tick(dt) {
   input.endFrame();
 
   fpsT += dt; fpsN++;
-  if (fpsT > 1) { App.fps = fpsN / fpsT; fpsT = 0; fpsN = 0; }
+  if (fpsT > 1) {
+    App.fps = fpsN / fpsT; fpsT = 0; fpsN = 0;
+    if (playing && (!App._perfEventT || App.elapsed - App._perfEventT >= 60)) {
+      App._perfEventT = App.elapsed;
+      backend.track('performance', 'sampled', {
+        fps: Math.round(App.fps),
+        quality: App.settings.quality,
+        viewport_width: innerWidth,
+        viewport_height: innerHeight,
+        mission_index: App.game.missionIdx,
+        input_method: inputMethod()
+      }, { dedupeKey: `performance:${Math.floor(App.elapsed / 60)}`, dedupeMs: 30_000 });
+    }
+  }
   void acc;
 }
 
@@ -776,13 +892,25 @@ addEventListener('error', (e) => {
     t.textContent = 'LINK FAILURE — ' + (e.message || 'unknown');
     t.style.color = '#ff5f56';
   }
+  backend.track('errors', 'runtime_error', {
+    phase: App.state === ST.BOOT ? 'boot' : 'runtime',
+    error_type: e.error?.name || 'javascript_error'
+  }, { dedupeKey: `error:${e.error?.name || 'javascript_error'}`, dedupeMs: 5000 });
   console.error(e.error || e.message);
 });
 
 boot().catch((err) => {
   console.error(err);
+  if (err instanceof BackendAccessError) {
+    $('accessDeniedMessage').textContent = err.playerMessage;
+    $('accessRetry').onclick = () => location.reload();
+    $('accessDenied').classList.remove('hidden');
+    return;
+  }
+  backend.track('errors', 'boot_failed', { error_type: err?.name || 'boot_error' },
+    { dedupeKey: 'boot-failed', dedupeMs: 60_000 });
   const t = $('loadtext');
-  if (t) { t.textContent = 'LINK FAILURE — ' + err.message; t.style.color = '#ff5f56'; }
+  if (t) { t.textContent = 'THE GAME COULD NOT START. RELOAD TO TRY AGAIN.'; t.style.color = '#ff5f56'; }
 });
 
 void PLAYABLE_R; void QUALITY; void Props;

--- a/src/main.js
+++ b/src/main.js
@@ -29,7 +29,7 @@ const App = {
     quality: guessQuality(), fov: 58, sens: 1.0, invertY: false,
     bloom: true, grain: 1.0, aberr: 1.0, stars: 1.0,
     volSfx: 0.8, volMusic: 0.5, music: true, tc: true, hudOn: true, autoCentre: 1,
-    hudScale: 1, realistic: false, comms: false, analyticsConsent: null
+    hudScale: 1, realistic: false, comms: false
   }, Save.settings()),
   elapsed: 0, sunAz: 4.35, paused: false
 };
@@ -92,20 +92,6 @@ function promptCloudConflict(details = {}) {
   });
 }
 
-function setAnalyticsChoice(granted) {
-  App.settings.analyticsConsent = granted;
-  Save.saveSettings(App.settings);
-  backend.setAnalyticsConsent(granted);
-  $('analyticsConsent').classList.add('hidden');
-  if (App.audio?.ready) App.audio.ui(granted ? 'ok' : 'tick');
-  if (App.audio) buildSettingsUI();
-}
-
-function maybeAskAnalyticsConsent() {
-  if (!backend.shouldAskForAnalyticsConsent || App.settings.analyticsConsent !== null) return;
-  $('analyticsConsent').classList.remove('hidden');
-}
-
 /* Optional imagery. The game generates everything it needs, so the repo ships
    with no third-party assets.
 
@@ -146,7 +132,6 @@ function loadTextures() {
 async function boot() {
   progress(0.005, 'verifying online services…');
   await backend.initialize();
-  backend.setAnalyticsConsent(App.settings.analyticsConsent === true);
   await backend.syncInitialSave(Save);
   Save.setSyncHandler((data, meta) => backend.queueCloudSave(data, meta));
 
@@ -235,7 +220,6 @@ async function boot() {
   await new Promise(r => setTimeout(r, 260));
   $('boot').classList.add('hidden');
   showMenu();
-  maybeAskAnalyticsConsent();
   requestAnimationFrame(frame);
 }
 
@@ -346,8 +330,6 @@ function wireUI() {
   };
   // one close path, so the ESC button and the Escape key cannot diverge
   document.querySelectorAll('[data-close]').forEach(b => b.onclick = closePanels);
-  $('analyticsDecline').onclick = () => setAnalyticsChoice(false);
-  $('analyticsAllow').onclick = () => setAnalyticsChoice(true);
   $('accessRetry').onclick = () => location.reload();
   addEventListener('beforeunload', () => {
     if (App.game && App.state >= ST.PLAY) Save.write(App.game.save());
@@ -408,11 +390,6 @@ function buildSettingsUI() {
     () => S.tc ? 1 : 0, (i) => { S.tc = !!i; App.game.tc = !!i; persist(); });
   seg('SCORE', 'generative, D minor, patient', ['OFF', 'ON'],
     () => S.music ? 1 : 0, (i) => { S.music = !!i; App.audio.setMusic(!!i); persist(); });
-  if (backend.analyticsAvailable) {
-    seg('USAGE ANALYTICS', 'anonymous mission, menu, performance, and error events', ['OFF', 'ON'],
-      () => S.analyticsConsent === true ? 1 : 0,
-      (i) => { S.analyticsConsent = !!i; backend.setAnalyticsConsent(!!i); persist(); });
-  }
   rng('FIELD OF VIEW', 'degrees', 42, 82, 1, () => S.fov, (v) => { S.fov = v; App.rig.fovScale = v / 58; persist(); });
   rng('LOOK SENSITIVITY', '', 0.25, 3, 0.05, () => S.sens, (v) => { S.sens = v; applySettings(); persist(); });
   rng('EFFECTS VOLUME', '', 0, 1, 0.05, () => S.volSfx, (v) => { S.volSfx = v; App.audio.setVolumes(v, S.volMusic); persist(); });

--- a/src/services/backend.js
+++ b/src/services/backend.js
@@ -154,8 +154,7 @@ export class RegolithBackend {
       apiOrigin: String(config.apiOrigin || '').replace(/\/$/, ''),
       cloudSavesEnabled: !!config.cloudSavesEnabled,
       analyticsEnabled: !!config.analyticsEnabled,
-      analyticsTestMode: !!config.analyticsTestMode,
-      gameVersion: config.gameVersion || '1.1.1',
+      gameVersion: config.gameVersion || '1.1.2',
       buildType: config.buildType || 'production'
     };
     Object.assign(this, {
@@ -165,7 +164,6 @@ export class RegolithBackend {
     this.valid = false;
     this.online = false;
     this.linkedUser = false;
-    this.analyticsConsent = false;
     this.active = false;
     this.eventQueue = [];
     this.eventSending = false;
@@ -187,7 +185,6 @@ export class RegolithBackend {
     return this.enabled && this.valid && this.online && this.config.cloudSavesEnabled &&
       this.linkedUser && !this.cloudDisabled;
   }
-  get shouldAskForAnalyticsConsent() { return this.analyticsAvailable; }
 
   _url(path) { return `${this.config.apiOrigin}${path}`; }
 
@@ -294,6 +291,12 @@ export class RegolithBackend {
       this.onStatus(this.linkedUser && this.config.cloudSavesEnabled
         ? 'Online services connected.'
         : 'Access verified. Cloud saves need a signed-in Glitch account.');
+      this.track('app_launch', 'session_started', {
+        session_id: this.sessionId,
+        game_version: this.config.gameVersion,
+        build_type: this.config.buildType,
+        platform: 'web'
+      }, { dedupeKey: `session:${this.sessionId}` });
       return { enabled: true, valid: true, installId: this.installId, linkedUser: this.linkedUser };
     } catch (error) {
       if (error instanceof BackendAccessError) throw error;
@@ -314,24 +317,8 @@ export class RegolithBackend {
     }
   }
 
-  setAnalyticsConsent(granted) {
-    this.analyticsConsent = granted === true;
-    if (!this.analyticsConsent) {
-      this.eventQueue.length = 0;
-      this._stopHeartbeat();
-      return;
-    }
-    if (this.active) this._startHeartbeat();
-    this.track('app_launch', 'session_started', {
-      session_id: this.sessionId,
-      game_version: this.config.gameVersion,
-      build_type: this.config.buildType,
-      platform: 'web'
-    }, { dedupeKey: `session:${this.sessionId}` });
-  }
-
   track(stepKey, actionKey, metadata = {}, options = {}) {
-    if (!this.analyticsAvailable || !this.analyticsConsent || !this.valid || !this.online) return false;
+    if (!this.analyticsAvailable || !this.valid || !this.online) return false;
     if (!SAFE_KEY.test(stepKey) || !SAFE_KEY.test(actionKey)) return false;
     const now = this.now();
     const dedupeKey = options.dedupeKey || `${stepKey}:${actionKey}:${JSON.stringify(metadata)}`;
@@ -400,7 +387,7 @@ export class RegolithBackend {
     this.playStartedAt = this.now();
     this.track('gameplay', 'started', { mode, resumed: !!resumed, ...context },
       { dedupeKey: `play:${this.sessionId}:${mode}:${this.playStartedAt}` });
-    if (this.analyticsConsent) this._startHeartbeat();
+    this._startHeartbeat();
   }
 
   endPlay(reason, context = {}) {
@@ -413,10 +400,10 @@ export class RegolithBackend {
   }
 
   _startHeartbeat() {
-    if (this.heartbeatTimer || !this.canHeartbeat || !this.online || !this.analyticsConsent || !this.setTimeoutImpl) return;
+    if (this.heartbeatTimer || !this.canHeartbeat || !this.online || !this.setTimeoutImpl) return;
     const run = async () => {
       this.heartbeatTimer = null;
-      if (!this.active || !this.analyticsConsent) return;
+      if (!this.active) return;
       try { await this._createInstall({ adopt: false }); } catch { /* heartbeat never interrupts play */ }
       this.heartbeatTimer = this.setTimeoutImpl(run, 30_000);
     };

--- a/src/services/backend.js
+++ b/src/services/backend.js
@@ -1,0 +1,580 @@
+const KEYS = {
+  userInstallId: 'regolith.glitch.user_install_id.v1',
+  installId: 'regolith.glitch.install_id.v1',
+  deviceId: 'regolith.glitch.device_id.v1',
+  lastValidAt: 'regolith.glitch.last_valid_at.v1'
+};
+
+const UUID = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+const SAFE_KEY = /^[a-z0-9_]{1,100}$/;
+const VALIDATION_GRACE_MS = 24 * 60 * 60 * 1000;
+
+export class BackendApiError extends Error {
+  constructor(status, body = {}) {
+    super(body.message || body.error || `Online service request failed (${status}).`);
+    this.name = 'BackendApiError';
+    this.status = status;
+    this.code = body.code || body.reason || null;
+    this.body = body;
+  }
+}
+
+export class BackendAccessError extends Error {
+  constructor(reason, message) {
+    super(message);
+    this.name = 'BackendAccessError';
+    this.reason = reason;
+    this.playerMessage = message;
+  }
+}
+
+function safeGet(storage, key) {
+  try { return storage.getItem(key); } catch { return null; }
+}
+
+function safeSet(storage, key, value) {
+  try { storage.setItem(key, value); } catch { /* private mode */ }
+}
+
+function randomId(cryptoImpl) {
+  if (cryptoImpl?.randomUUID) return cryptoImpl.randomUUID();
+  const bytes = new Uint8Array(16);
+  cryptoImpl?.getRandomValues?.(bytes);
+  bytes[6] = (bytes[6] & 0x0f) | 0x40;
+  bytes[8] = (bytes[8] & 0x3f) | 0x80;
+  const hex = [...bytes].map(v => v.toString(16).padStart(2, '0')).join('');
+  return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20)}`;
+}
+
+function storedId(storage, key, cryptoImpl, preferred = null) {
+  if (preferred) { safeSet(storage, key, preferred); return preferred; }
+  const current = safeGet(storage, key);
+  if (current) return current;
+  const created = randomId(cryptoImpl);
+  safeSet(storage, key, created);
+  return created;
+}
+
+function bytesToBase64(bytes, btoaImpl = globalThis.btoa) {
+  let binary = '';
+  const chunk = 0x8000;
+  for (let i = 0; i < bytes.length; i += chunk) {
+    binary += String.fromCharCode(...bytes.subarray(i, i + chunk));
+  }
+  return btoaImpl(binary);
+}
+
+function base64ToBytes(value, atobImpl = globalThis.atob) {
+  const binary = atobImpl(value);
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i);
+  return bytes;
+}
+
+async function sha256(bytes, cryptoImpl) {
+  const digest = await cryptoImpl.subtle.digest('SHA-256', bytes);
+  return [...new Uint8Array(digest)].map(v => v.toString(16).padStart(2, '0')).join('');
+}
+
+export async function encodeCloudSave(value, cryptoImpl = globalThis.crypto) {
+  const bytes = new TextEncoder().encode(JSON.stringify(value));
+  return {
+    payload: bytesToBase64(bytes),
+    checksum: await sha256(bytes, cryptoImpl),
+    sizeBytes: bytes.byteLength
+  };
+}
+
+export async function decodeCloudSave(record, cryptoImpl = globalThis.crypto) {
+  if (!record?.payload || typeof record.payload !== 'string') throw new Error('Cloud save payload is missing.');
+  const bytes = base64ToBytes(record.payload);
+  const checksum = await sha256(bytes, cryptoImpl);
+  if (checksum !== record.checksum) throw new Error('Cloud save checksum does not match.');
+  return JSON.parse(new TextDecoder().decode(bytes));
+}
+
+function cleanMetadata(value, depth = 0) {
+  if (depth > 3 || value === null || value === undefined) return undefined;
+  if (typeof value === 'boolean' || typeof value === 'number') return Number.isFinite(value) ? value : undefined;
+  if (typeof value === 'string') return value.slice(0, 200);
+  if (Array.isArray(value)) return value.slice(0, 20).map(v => cleanMetadata(v, depth + 1)).filter(v => v !== undefined);
+  if (typeof value !== 'object') return undefined;
+  const result = {};
+  for (const [rawKey, rawValue] of Object.entries(value)) {
+    const key = rawKey.slice(0, 64);
+    if (!key || /(token|secret|password|email|chat|message|dialogue|player_text)/i.test(key)) continue;
+    const cleaned = cleanMetadata(rawValue, depth + 1);
+    if (cleaned !== undefined) result[key] = cleaned;
+  }
+  return result;
+}
+
+function deviceType(navigatorImpl, matchMediaImpl) {
+  const coarse = matchMediaImpl?.('(pointer: coarse)')?.matches;
+  const ua = String(navigatorImpl?.userAgent || '');
+  if (/tablet|ipad/i.test(ua)) return 'tablet';
+  if (coarse || /mobile|android|iphone/i.test(ua)) return 'mobile';
+  return 'desktop';
+}
+
+function operatingSystem(navigatorImpl) {
+  return String(navigatorImpl?.userAgentData?.platform || navigatorImpl?.platform || 'browser').slice(0, 255);
+}
+
+function accessMessage(reason) {
+  switch (reason) {
+    case 'LICENSE_EXPIRED_OR_MISSING': return 'This copy could not be licensed. Your local save is safe. Check your Glitch account and try again.';
+    case 'TRIAL_EXPIRED': return 'This trial has ended. Your local save is safe. Open the game from Glitch to continue.';
+    case 'AGE_GATE_LOCKED': return 'This account cannot open the game because its age settings do not allow access.';
+    case 'ACCOUNT_SUSPENDED': return 'This account cannot open the game right now. Contact Glitch support for help.';
+    case 'SUBSCRIPTION_REQUIRED': return 'A Glitch subscription is required to open this build.';
+    default: return 'We could not verify access to the game. Your local save is safe. Check your connection and try again.';
+  }
+}
+
+export class RegolithBackend {
+  constructor({
+    config = globalThis.REGOLITH_RUNTIME_CONFIG?.glitch || {},
+    storage = globalThis.localStorage,
+    fetchImpl = globalThis.fetch?.bind(globalThis),
+    cryptoImpl = globalThis.crypto,
+    locationImpl = globalThis.location,
+    navigatorImpl = globalThis.navigator,
+    matchMediaImpl = globalThis.matchMedia?.bind(globalThis),
+    now = () => Date.now(),
+    setTimeoutImpl = globalThis.setTimeout?.bind(globalThis),
+    clearTimeoutImpl = globalThis.clearTimeout?.bind(globalThis),
+    onStatus = () => {},
+    onConflict = async () => 'keep_server'
+  } = {}) {
+    this.config = {
+      enabled: !!config.enabled,
+      titleId: config.titleId || '',
+      environment: config.environment || 'development',
+      apiOrigin: String(config.apiOrigin || '').replace(/\/$/, ''),
+      cloudSavesEnabled: !!config.cloudSavesEnabled,
+      analyticsEnabled: !!config.analyticsEnabled,
+      analyticsTestMode: !!config.analyticsTestMode,
+      gameVersion: config.gameVersion || '1.1.1',
+      buildType: config.buildType || 'production'
+    };
+    Object.assign(this, {
+      storage, fetchImpl, cryptoImpl, locationImpl, navigatorImpl, matchMediaImpl,
+      now, setTimeoutImpl, clearTimeoutImpl, onStatus, onConflict
+    });
+    this.valid = false;
+    this.online = false;
+    this.linkedUser = false;
+    this.analyticsConsent = false;
+    this.active = false;
+    this.eventQueue = [];
+    this.eventSending = false;
+    this.eventRetryTimer = null;
+    this.eventDedupe = new Map();
+    this.previousStep = null;
+    this.cloudVersion = 0;
+    this.cloudChecksum = null;
+    this.cloudRecord = null;
+    this.cloudPending = null;
+    this.cloudSending = false;
+    this.cloudDisabled = false;
+    this.sessionStartedAt = this.now();
+  }
+
+  get enabled() { return this.config.enabled; }
+  get analyticsAvailable() { return this.enabled && this.config.analyticsEnabled; }
+  get cloudAvailable() {
+    return this.enabled && this.valid && this.online && this.config.cloudSavesEnabled &&
+      this.linkedUser && !this.cloudDisabled;
+  }
+  get shouldAskForAnalyticsConsent() { return this.analyticsAvailable; }
+
+  _url(path) { return `${this.config.apiOrigin}${path}`; }
+
+  async _request(path, { method = 'GET', body, keepalive = false } = {}) {
+    let response;
+    try {
+      response = await this.fetchImpl(this._url(path), {
+        method,
+        headers: body === undefined ? { Accept: 'application/json' } :
+          { Accept: 'application/json', 'Content-Type': 'application/json' },
+        body: body === undefined ? undefined : JSON.stringify(body),
+        credentials: 'same-origin',
+        keepalive
+      });
+    } catch {
+      throw new BackendApiError(0, { code: 'NETWORK_ERROR', message: 'Online services are unreachable.' });
+    }
+    const text = await response.text();
+    let data = {};
+    if (text) {
+      try { data = JSON.parse(text); } catch { data = { message: 'Online services returned an unreadable response.' }; }
+    }
+    if (!response.ok) throw new BackendApiError(response.status, data);
+    return data;
+  }
+
+  _installBody() {
+    return {
+      user_install_id: this.userInstallId,
+      platform: 'web',
+      device_type: deviceType(this.navigatorImpl, this.matchMediaImpl),
+      operating_system: operatingSystem(this.navigatorImpl),
+      game_version: this.config.gameVersion,
+      build_type: this.config.buildType,
+      device_id: this.deviceId,
+      session_id: this.sessionId
+    };
+  }
+
+  async _createInstall({ adopt = true } = {}) {
+    const response = await this._request('/api/glitch/installs', { method: 'POST', body: this._installBody() });
+    const install = response.data || response;
+    if (!install?.id || !UUID.test(install.id)) {
+      throw new BackendApiError(502, { code: 'INVALID_INSTALL_RESPONSE', message: 'Glitch did not return an install ID.' });
+    }
+    if (adopt) {
+      this.installId = install.id;
+      safeSet(this.storage, KEYS.installId, install.id);
+    }
+    return install;
+  }
+
+  async _validateInstall(installId) {
+    return this._request(`/api/glitch/installs/${encodeURIComponent(installId)}/validate`, {
+      method: 'POST', body: {}
+    });
+  }
+
+  async initialize() {
+    if (!this.enabled) return { enabled: false };
+    if (!this.fetchImpl || !this.storage || !this.cryptoImpl) {
+      throw new BackendAccessError('CLIENT_UNAVAILABLE', accessMessage());
+    }
+
+    const params = new URLSearchParams(this.locationImpl?.search || '');
+    const launchTitleId = params.get('title_id') || params.get('game_id');
+    if (launchTitleId && launchTitleId !== this.config.titleId) {
+      throw new BackendAccessError('TITLE_MISMATCH', 'This launch link belongs to a different game. Open Regolith again from its Glitch page.');
+    }
+    const launchUserInstallId = params.get('user_install_id');
+    const launchInstallId = params.get('install_id');
+    const launchSessionId = params.get('session_id');
+    this.userInstallId = storedId(this.storage, KEYS.userInstallId, this.cryptoImpl, launchUserInstallId);
+    this.deviceId = storedId(this.storage, KEYS.deviceId, this.cryptoImpl);
+    this.sessionId = (launchSessionId || randomId(this.cryptoImpl)).slice(0, 255);
+    this.installId = launchInstallId || safeGet(this.storage, KEYS.installId);
+    this.canHeartbeat = !launchInstallId || !!launchUserInstallId;
+
+    let install = null;
+    try {
+      let validation;
+      if (launchInstallId && UUID.test(launchInstallId)) {
+        safeSet(this.storage, KEYS.installId, launchInstallId);
+        try {
+          validation = await this._validateInstall(launchInstallId);
+        } catch (error) {
+          if (error.status !== 404) throw error;
+          install = await this._createInstall();
+          validation = await this._validateInstall(install.id);
+        }
+      } else {
+        install = await this._createInstall();
+        validation = await this._validateInstall(install.id);
+      }
+
+      if (!validation.valid) {
+        const reason = validation.reason || validation.code || 'ACCESS_DENIED';
+        throw new BackendAccessError(reason, accessMessage(reason));
+      }
+      this.valid = true;
+      this.online = true;
+      this.linkedUser = !!(validation.user_id || install?.user_id);
+      safeSet(this.storage, KEYS.lastValidAt, String(this.now()));
+      this.onStatus(this.linkedUser && this.config.cloudSavesEnabled
+        ? 'Online services connected.'
+        : 'Access verified. Cloud saves need a signed-in Glitch account.');
+      return { enabled: true, valid: true, installId: this.installId, linkedUser: this.linkedUser };
+    } catch (error) {
+      if (error instanceof BackendAccessError) throw error;
+      if (error instanceof BackendApiError && error.status === 403) {
+        const reason = error.code || 'ACCESS_DENIED';
+        throw new BackendAccessError(reason, accessMessage(reason));
+      }
+      const lastValidAt = Number(safeGet(this.storage, KEYS.lastValidAt) || 0);
+      const storedInstallId = safeGet(this.storage, KEYS.installId);
+      if (storedInstallId && UUID.test(storedInstallId) && this.now() - lastValidAt <= VALIDATION_GRACE_MS) {
+        this.installId = storedInstallId;
+        this.valid = true;
+        this.online = false;
+        this.onStatus('Playing offline. Progress is saved on this device and will sync later.');
+        return { enabled: true, valid: true, offlineGrace: true, installId: this.installId };
+      }
+      throw new BackendAccessError(error.code || 'VALIDATION_UNAVAILABLE', accessMessage());
+    }
+  }
+
+  setAnalyticsConsent(granted) {
+    this.analyticsConsent = granted === true;
+    if (!this.analyticsConsent) {
+      this.eventQueue.length = 0;
+      this._stopHeartbeat();
+      return;
+    }
+    if (this.active) this._startHeartbeat();
+    this.track('app_launch', 'session_started', {
+      session_id: this.sessionId,
+      game_version: this.config.gameVersion,
+      build_type: this.config.buildType,
+      platform: 'web'
+    }, { dedupeKey: `session:${this.sessionId}` });
+  }
+
+  track(stepKey, actionKey, metadata = {}, options = {}) {
+    if (!this.analyticsAvailable || !this.analyticsConsent || !this.valid || !this.online) return false;
+    if (!SAFE_KEY.test(stepKey) || !SAFE_KEY.test(actionKey)) return false;
+    const now = this.now();
+    const dedupeKey = options.dedupeKey || `${stepKey}:${actionKey}:${JSON.stringify(metadata)}`;
+    const last = this.eventDedupe.get(dedupeKey) || 0;
+    if (now - last < (options.dedupeMs ?? 1000)) return false;
+    this.eventDedupe.set(dedupeKey, now);
+    if (this.eventDedupe.size > 200) {
+      for (const [key, stamp] of this.eventDedupe) if (now - stamp > 60_000) this.eventDedupe.delete(key);
+    }
+    const event = {
+      game_install_id: this.installId,
+      step_key: stepKey,
+      action_key: actionKey,
+      metadata: cleanMetadata({
+        ...metadata,
+        session_id: this.sessionId,
+        game_version: this.config.gameVersion,
+        build_type: this.config.buildType
+      }),
+      event_timestamp: new Date(now).toISOString()
+    };
+    if (this.previousStep && this.previousStep !== stepKey) event.previous_step_key = this.previousStep;
+    if (options.stepLabel) event.step_label = options.stepLabel;
+    if (options.stepDescription) event.step_description = options.stepDescription;
+    if (options.eventLabel) event.event_label = options.eventLabel;
+    if (options.eventDescription) event.event_description = options.eventDescription;
+    this.previousStep = stepKey;
+    this.eventQueue.push({ event, attempts: 0 });
+    if (this.eventQueue.length > 100) this.eventQueue.shift();
+    void this._drainEvents();
+    return true;
+  }
+
+  async _drainEvents(keepalive = false) {
+    if (this.eventSending || !this.eventQueue.length) return;
+    this.eventSending = true;
+    try {
+      while (this.eventQueue.length) {
+        const item = this.eventQueue[0];
+        try {
+          await this._request('/api/glitch/events', { method: 'POST', body: item.event, keepalive });
+          this.eventQueue.shift();
+        } catch (error) {
+          item.attempts++;
+          if ((error.status >= 400 && error.status < 500 && error.status !== 429) || item.attempts >= 4) {
+            this.eventQueue.shift();
+            continue;
+          }
+          if (!this.eventRetryTimer && this.setTimeoutImpl) {
+            const wait = Math.min(30_000, 1000 * 2 ** (item.attempts - 1));
+            this.eventRetryTimer = this.setTimeoutImpl(() => {
+              this.eventRetryTimer = null;
+              void this._drainEvents();
+            }, wait);
+          }
+          break;
+        }
+      }
+    } finally {
+      this.eventSending = false;
+    }
+  }
+
+  startPlay(mode, resumed, context = {}) {
+    this.active = true;
+    this.playStartedAt = this.now();
+    this.track('gameplay', 'started', { mode, resumed: !!resumed, ...context },
+      { dedupeKey: `play:${this.sessionId}:${mode}:${this.playStartedAt}` });
+    if (this.analyticsConsent) this._startHeartbeat();
+  }
+
+  endPlay(reason, context = {}) {
+    const duration = Math.max(0, Math.round((this.now() - (this.playStartedAt || this.sessionStartedAt)) / 1000));
+    this.track('session_end', 'ended', { reason, duration_seconds: duration, ...context },
+      { dedupeKey: `end:${this.sessionId}:${reason}`, dedupeMs: 60_000 });
+    this.active = false;
+    this._stopHeartbeat();
+    void this._drainEvents(reason === 'page_unload');
+  }
+
+  _startHeartbeat() {
+    if (this.heartbeatTimer || !this.canHeartbeat || !this.online || !this.analyticsConsent || !this.setTimeoutImpl) return;
+    const run = async () => {
+      this.heartbeatTimer = null;
+      if (!this.active || !this.analyticsConsent) return;
+      try { await this._createInstall({ adopt: false }); } catch { /* heartbeat never interrupts play */ }
+      this.heartbeatTimer = this.setTimeoutImpl(run, 30_000);
+    };
+    this.heartbeatTimer = this.setTimeoutImpl(run, 30_000);
+  }
+
+  _stopHeartbeat() {
+    if (this.heartbeatTimer && this.clearTimeoutImpl) this.clearTimeoutImpl(this.heartbeatTimer);
+    this.heartbeatTimer = null;
+  }
+
+  async syncInitialSave(saveStore) {
+    this.saveStore = saveStore;
+    if (!this.cloudAvailable) return;
+    try {
+      const response = await this._request(
+        `/api/glitch/installs/${encodeURIComponent(this.installId)}/saves?include_payload=1`);
+      const records = Array.isArray(response.data) ? response.data : [];
+      const remote = records.find(record => record.slot_index === 0) || null;
+      const local = saveStore.read();
+      const meta = saveStore.meta();
+      if (!remote) {
+        if (local) this.queueCloudSave(local, meta);
+        return;
+      }
+      const remoteData = await decodeCloudSave(remote, this.cryptoImpl);
+      this.cloudRecord = remote;
+      this.cloudVersion = remote.version || 0;
+      this.cloudChecksum = remote.checksum;
+      if (!local) {
+        saveStore.replaceFromCloud(remoteData, remote);
+        this.track('cloud_save', 'restored', { version: remote.version });
+        this.onStatus('Cloud save restored.');
+        return;
+      }
+      const encodedLocal = await encodeCloudSave(local, this.cryptoImpl);
+      if (encodedLocal.checksum === remote.checksum) {
+        saveStore.markCloudSynced(remote.version, remote.checksum);
+        this.onStatus('Cloud save is up to date.');
+        return;
+      }
+      if (meta.cloudChecksum === remote.checksum) {
+        this.queueCloudSave(local, meta);
+        return;
+      }
+      if (meta.cloudChecksum === encodedLocal.checksum) {
+        saveStore.replaceFromCloud(remoteData, remote);
+        this.track('cloud_save', 'restored', { version: remote.version });
+        this.onStatus('Newer cloud progress restored.');
+        return;
+      }
+      await this._uploadSave(local, { ...meta, cloudVersion: meta.cloudVersion || 0 });
+    } catch (error) {
+      if (error.status === 403 && error.code === 'GUEST_NOT_ALLOWED') {
+        this.cloudDisabled = true;
+        this.onStatus('Cloud saves need a signed-in Glitch account. Progress remains on this device.');
+      } else {
+        this.onStatus('Cloud sync is temporarily unavailable. Progress remains on this device.');
+        this.track('cloud_save', 'sync_failed', { error_type: error.code || 'unavailable' });
+      }
+    }
+  }
+
+  queueCloudSave(data, meta = {}) {
+    if (!this.cloudAvailable) return;
+    this.cloudPending = { data, meta };
+    void this._drainCloud();
+  }
+
+  async _drainCloud() {
+    if (this.cloudSending || !this.cloudPending) return;
+    this.cloudSending = true;
+    try {
+      while (this.cloudPending && this.cloudAvailable) {
+        const pending = this.cloudPending;
+        this.cloudPending = null;
+        try { await this._uploadSave(pending.data, pending.meta); }
+        catch (error) {
+          if (error.status === 403 && error.code === 'GUEST_NOT_ALLOWED') this.cloudDisabled = true;
+          else this.cloudPending = pending;
+          this.onStatus('Cloud sync paused. Progress remains saved on this device.');
+          this.track('cloud_save', 'sync_failed', { error_type: error.code || 'unavailable' });
+          break;
+        }
+      }
+    } finally {
+      this.cloudSending = false;
+    }
+  }
+
+  async _uploadSave(data, meta = {}) {
+    const encoded = await encodeCloudSave(data, this.cryptoImpl);
+    if (encoded.checksum === this.cloudChecksum) return;
+    const nowIso = new Date(this.now()).toISOString();
+    const body = {
+      slot_index: 0,
+      payload: encoded.payload,
+      checksum: encoded.checksum,
+      save_type: 'auto',
+      client_timestamp: nowIso,
+      base_version: Number.isInteger(meta.cloudVersion) ? meta.cloudVersion : this.cloudVersion,
+      slot_name: 'Autosave',
+      metadata: {
+        mission_index: Number(data.missionIdx || 0),
+        relays_placed: Number(data.relaysPlaced || 0),
+        samples_excavated: Number(data.anoms?.filter?.(v => v === 1).length || 0)
+      },
+      device_id: this.deviceId,
+      platform: 'web',
+      game_version: this.config.gameVersion,
+      last_played_at: nowIso,
+      play_duration_seconds: Math.max(0, Math.round(Number(data.met || 0)))
+    };
+    try {
+      const response = await this._request(
+        `/api/glitch/installs/${encodeURIComponent(this.installId)}/saves`,
+        { method: 'POST', body });
+      const record = response.data || response;
+      this.cloudRecord = record;
+      this.cloudVersion = record.version || this.cloudVersion;
+      this.cloudChecksum = record.checksum || encoded.checksum;
+      this.saveStore?.markCloudSynced(this.cloudVersion, this.cloudChecksum);
+      this.track('cloud_save', 'synced', { version: this.cloudVersion, size_bytes: encoded.sizeBytes });
+      this.onStatus('Progress saved to the cloud.');
+    } catch (error) {
+      if (error.status !== 409) throw error;
+      const conflict = error.body;
+      this.track('cloud_save', 'conflict_detected', {
+        server_version: conflict.server_version,
+        local_base_version: conflict.your_base_version
+      });
+      const choice = await this.onConflict({
+        localUpdatedAt: meta.updatedAt || nowIso,
+        serverVersion: conflict.server_version
+      });
+      const resolvedResponse = await this._request(
+        `/api/glitch/installs/${encodeURIComponent(this.installId)}/saves/${encodeURIComponent(conflict.save_id)}/resolve`,
+        { method: 'POST', body: { conflict_id: conflict.conflict_id, choice } });
+      const resolved = resolvedResponse.data || resolvedResponse;
+      this.cloudVersion = resolved.version || conflict.server_version || this.cloudVersion;
+      this.cloudChecksum = resolved.checksum || (choice === 'use_client' ? encoded.checksum : null);
+      if (choice === 'keep_server') {
+        const latestResponse = await this._request(
+          `/api/glitch/installs/${encodeURIComponent(this.installId)}/saves?include_payload=1`);
+        const latest = (latestResponse.data || []).find(record => record.slot_index === 0);
+        if (latest) {
+          const cloudData = await decodeCloudSave(latest, this.cryptoImpl);
+          this.cloudVersion = latest.version;
+          this.cloudChecksum = latest.checksum;
+          this.saveStore?.replaceFromCloud(cloudData, latest);
+        }
+      } else {
+        this.saveStore?.markCloudSynced(this.cloudVersion, this.cloudChecksum);
+      }
+      this.track('cloud_save', 'conflict_resolved', { choice, version: this.cloudVersion });
+      this.onStatus(choice === 'keep_server' ? 'Cloud progress restored.' : 'This device was saved to the cloud.');
+    }
+  }
+}
+
+export function createBrowserBackend(options = {}) { return new RegolithBackend(options); }

--- a/src/services/backend.js
+++ b/src/services/backend.js
@@ -144,8 +144,7 @@ export class RegolithBackend {
     now = () => Date.now(),
     setTimeoutImpl = globalThis.setTimeout?.bind(globalThis),
     clearTimeoutImpl = globalThis.clearTimeout?.bind(globalThis),
-    onStatus = () => {},
-    onConflict = async () => 'keep_server'
+    onStatus = () => {}
   } = {}) {
     this.config = {
       enabled: !!config.enabled,
@@ -154,12 +153,12 @@ export class RegolithBackend {
       apiOrigin: String(config.apiOrigin || '').replace(/\/$/, ''),
       cloudSavesEnabled: !!config.cloudSavesEnabled,
       analyticsEnabled: !!config.analyticsEnabled,
-      gameVersion: config.gameVersion || '1.1.2',
+      gameVersion: config.gameVersion || '1.1.3',
       buildType: config.buildType || 'production'
     };
     Object.assign(this, {
       storage, fetchImpl, cryptoImpl, locationImpl, navigatorImpl, matchMediaImpl,
-      now, setTimeoutImpl, clearTimeoutImpl, onStatus, onConflict
+      now, setTimeoutImpl, clearTimeoutImpl, onStatus
     });
     this.valid = false;
     this.online = false;
@@ -455,7 +454,16 @@ export class RegolithBackend {
         this.onStatus('Newer cloud progress restored.');
         return;
       }
-      await this._uploadSave(local, { ...meta, cloudVersion: meta.cloudVersion || 0 });
+      saveStore.replaceFromCloud(remoteData, remote);
+      this.track('cloud_save', 'conflict_detected', {
+        server_version: remote.version,
+        local_base_version: meta.cloudVersion || 0,
+        automatic: true
+      });
+      this.track('cloud_save', 'conflict_resolved', {
+        choice: 'keep_server', version: remote.version, automatic: true
+      });
+      this.onStatus('Cloud progress restored automatically.');
     } catch (error) {
       if (error.status === 403 && error.code === 'GUEST_NOT_ALLOWED') {
         this.cloudDisabled = true;
@@ -535,31 +543,45 @@ export class RegolithBackend {
         server_version: conflict.server_version,
         local_base_version: conflict.your_base_version
       });
-      const choice = await this.onConflict({
-        localUpdatedAt: meta.updatedAt || nowIso,
-        serverVersion: conflict.server_version
-      });
+      const choice = 'keep_server';
       const resolvedResponse = await this._request(
         `/api/glitch/installs/${encodeURIComponent(this.installId)}/saves/${encodeURIComponent(conflict.save_id)}/resolve`,
         { method: 'POST', body: { conflict_id: conflict.conflict_id, choice } });
       const resolved = resolvedResponse.data || resolvedResponse;
       this.cloudVersion = resolved.version || conflict.server_version || this.cloudVersion;
-      this.cloudChecksum = resolved.checksum || (choice === 'use_client' ? encoded.checksum : null);
-      if (choice === 'keep_server') {
-        const latestResponse = await this._request(
-          `/api/glitch/installs/${encodeURIComponent(this.installId)}/saves?include_payload=1`);
-        const latest = (latestResponse.data || []).find(record => record.slot_index === 0);
-        if (latest) {
-          const cloudData = await decodeCloudSave(latest, this.cryptoImpl);
-          this.cloudVersion = latest.version;
-          this.cloudChecksum = latest.checksum;
-          this.saveStore?.replaceFromCloud(cloudData, latest);
+      this.cloudChecksum = resolved.checksum || null;
+      try {
+        let latest = resolved?.payload ? resolved : null;
+        if (!latest) {
+          const latestResponse = await this._request(
+            `/api/glitch/installs/${encodeURIComponent(this.installId)}/saves?include_payload=1`);
+          latest = (latestResponse.data || []).find(record => record.slot_index === 0) || null;
         }
-      } else {
-        this.saveStore?.markCloudSynced(this.cloudVersion, this.cloudChecksum);
+        if (!latest) throw new BackendApiError(502, {
+          code: 'CLOUD_SAVE_MISSING', message: 'The resolved cloud save could not be loaded.'
+        });
+        const cloudData = await decodeCloudSave(latest, this.cryptoImpl);
+        this.cloudVersion = latest.version || this.cloudVersion;
+        this.cloudChecksum = latest.checksum;
+        this.saveStore?.replaceFromCloud(cloudData, latest);
+      } catch (error) {
+        // The server already kept its cloud copy. Disable further uploads for
+        // this session so stale local data cannot overwrite it after a
+        // transient read failure; the next online launch will restore it.
+        this.cloudDisabled = true;
+        this.track('cloud_save', 'conflict_resolved', {
+          choice, version: this.cloudVersion, automatic: true, local_restore: 'deferred'
+        });
+        this.track('cloud_save', 'sync_failed', {
+          error_type: error.code || 'restore_unavailable', phase: 'restore_after_conflict'
+        });
+        this.onStatus('Cloud copy kept. It will restore on the next online launch.');
+        return;
       }
-      this.track('cloud_save', 'conflict_resolved', { choice, version: this.cloudVersion });
-      this.onStatus(choice === 'keep_server' ? 'Cloud progress restored.' : 'This device was saved to the cloud.');
+      this.track('cloud_save', 'conflict_resolved', {
+        choice, version: this.cloudVersion, automatic: true, local_restore: 'completed'
+      });
+      this.onStatus('Cloud progress restored automatically.');
     }
   }
 }

--- a/src/ui/styles.css
+++ b/src/ui/styles.css
@@ -81,6 +81,7 @@ button{font:inherit;color:inherit;background:none;border:none;cursor:pointer;}
 .brief em{color:var(--amber);font-style:normal}
 .menu-actions{display:flex;flex-direction:column;gap:9px;max-width:330px}
 .hint{margin-top:26px;font-size:10px;letter-spacing:.2em;color:rgba(216,210,198,.32)}
+.backend-status{margin-top:14px;max-width:52ch;font-size:10px;line-height:1.55;letter-spacing:.08em;color:var(--cyan)}
 
 .btn{
   position:relative;padding:13px 20px;letter-spacing:.22em;font-size:12px;
@@ -95,6 +96,15 @@ button{font:inherit;color:inherit;background:none;border:none;cursor:pointer;}
 .btn.ghost{border-color:var(--hair);color:var(--bone-dim)}
 .btn.ghost:hover{color:var(--bone)}
 .btn.danger:hover{border-color:rgba(255,95,86,.5);background:rgba(255,95,86,.10);color:#ffb8b3}
+
+.overlay.choice{z-index:80;padding:24px}
+.choice-card{position:relative;z-index:1;width:min(620px,94vw);padding:34px;border:1px solid var(--hair2);background:rgba(5,7,12,.96);box-shadow:0 24px 90px rgba(0,0,0,.55)}
+.choice-card h2{margin:9px 0 18px;font-size:clamp(18px,3vw,27px);font-weight:400;letter-spacing:.16em}
+.choice-card p{font-size:12px;line-height:1.75;color:#aaa599;max-width:68ch}
+.choice-card .choice-note{margin-top:12px;color:rgba(216,210,198,.48);font-size:10px}
+.choice-actions{display:flex;justify-content:flex-end;gap:10px;margin-top:26px;flex-wrap:wrap}
+.choice-actions .btn{text-align:center}
+.alert-text{color:var(--red)}
 
 .dossier{border:1px solid var(--hair);padding:22px;background:rgba(216,210,198,.02)}
 .dossier-row{display:flex;justify-content:space-between;gap:16px;padding:9px 0;border-bottom:1px dashed var(--hair);font-size:11px;letter-spacing:.14em}

--- a/test/backend-client.test.js
+++ b/test/backend-client.test.js
@@ -35,8 +35,7 @@ function baseConfig(overrides = {}) {
     apiOrigin: '',
     cloudSavesEnabled: true,
     analyticsEnabled: true,
-    analyticsTestMode: false,
-    gameVersion: '1.1.1',
+    gameVersion: '1.1.2',
     buildType: 'production',
     ...overrides
   };
@@ -118,7 +117,7 @@ test('install creation is followed by validation and identifiers are persisted',
   assert.equal(calls[0].url, '/api/glitch/installs');
   assert.equal(calls[1].url, `/api/glitch/installs/${INSTALL_ID}/validate`);
   assert.equal(calls[0].body.platform, 'web');
-  assert.equal(calls[0].body.game_version, '1.1.1');
+  assert.equal(calls[0].body.game_version, '1.1.2');
   assert.ok(calls[0].body.user_install_id);
   assert.equal(storage.getItem('regolith.glitch.install_id.v1'), INSTALL_ID);
 });
@@ -130,7 +129,8 @@ test('desktop launch install ID is validated before fallback creation', async ()
     fetchImpl: async (url) => { calls.push(url); return response({ valid: true, user_id: 'user' }); }
   });
   await client.initialize();
-  assert.deepEqual(calls, [`/api/glitch/installs/${INSTALL_ID}/validate`]);
+  assert.deepEqual(calls.filter(url => url !== '/api/glitch/events'),
+    [`/api/glitch/installs/${INSTALL_ID}/validate`]);
   assert.equal(client.userInstallId, 'device-7');
   assert.equal(client.sessionId, 'session-9');
 });
@@ -147,7 +147,7 @@ test('missing desktop install is recreated and revalidated', async () => {
     }
   });
   await client.initialize();
-  assert.deepEqual(calls, [
+  assert.deepEqual(calls.filter(url => url !== '/api/glitch/events'), [
     `/api/glitch/installs/${INSTALL_ID}/validate`,
     '/api/glitch/installs',
     `/api/glitch/installs/${INSTALL_ID}/validate`
@@ -180,22 +180,22 @@ test('recent successful validation grants a bounded offline grace period', async
   assert.equal(client.online, false);
 });
 
-test('analytics requires production permission and explicit consent', async () => {
-  let eventCalls = 0;
+test('analytics starts automatically whenever the Glitch backend is enabled', async () => {
+  const events = [];
   const client = createClient({
-    config: baseConfig({ analyticsEnabled: false }),
-    fetchImpl: async (url) => {
+    config: baseConfig({ environment: 'development' }),
+    fetchImpl: async (url, options) => {
       if (url === '/api/glitch/installs') return response({ data: { id: INSTALL_ID } }, 201);
       if (url.endsWith('/validate')) return response({ valid: true });
-      eventCalls++;
+      events.push(JSON.parse(options.body));
       return response({ data: {} }, 201);
     }
   });
   await client.initialize();
-  client.setAnalyticsConsent(true);
-  client.track('main_menu', 'viewed');
   await settle();
-  assert.equal(eventCalls, 0);
+  assert.equal(events.length, 1);
+  assert.equal(events[0].step_key, 'app_launch');
+  assert.equal(events[0].action_key, 'session_started');
 });
 
 test('analytics payloads contain stable context, remove sensitive keys, and deduplicate', async () => {
@@ -209,7 +209,6 @@ test('analytics payloads contain stable context, remove sensitive keys, and dedu
     }
   });
   await client.initialize();
-  client.setAnalyticsConsent(true);
   await settle();
   events.length = 0;
   client.track('mission_01', 'objective_completed', {
@@ -220,7 +219,7 @@ test('analytics payloads contain stable context, remove sensitive keys, and dedu
   assert.equal(events.length, 1);
   assert.equal(events[0].game_install_id, INSTALL_ID);
   assert.equal(events[0].step_key, 'mission_01');
-  assert.equal(events[0].metadata.game_version, '1.1.1');
+  assert.equal(events[0].metadata.game_version, '1.1.2');
   assert.equal(events[0].metadata.password, undefined);
   assert.equal(events[0].metadata.private_message, undefined);
 });
@@ -234,7 +233,6 @@ test('analytics provider failures never reject gameplay calls', async () => {
     }
   });
   await client.initialize();
-  client.setAnalyticsConsent(true);
   assert.doesNotThrow(() => client.track('gameplay', 'started'));
   await settle();
   assert.ok(client.eventQueue.length >= 1);

--- a/test/backend-client.test.js
+++ b/test/backend-client.test.js
@@ -1,0 +1,323 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { webcrypto } from 'node:crypto';
+import {
+  BackendAccessError,
+  RegolithBackend,
+  decodeCloudSave,
+  encodeCloudSave
+} from '../src/services/backend.js';
+
+const INSTALL_ID = '11111111-1111-4111-8111-111111111111';
+const SAVE_ID = '22222222-2222-4222-8222-222222222222';
+const CONFLICT_ID = '33333333-3333-4333-8333-333333333333';
+const TITLE_ID = '6bd2c447-1770-441b-b94b-bceed5e81e87';
+
+class MemoryStorage {
+  constructor(seed = {}) { this.values = new Map(Object.entries(seed)); }
+  getItem(key) { return this.values.has(key) ? this.values.get(key) : null; }
+  setItem(key, value) { this.values.set(key, String(value)); }
+  removeItem(key) { this.values.delete(key); }
+}
+
+function response(body, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' }
+  });
+}
+
+function baseConfig(overrides = {}) {
+  return {
+    enabled: true,
+    titleId: TITLE_ID,
+    environment: 'production',
+    apiOrigin: '',
+    cloudSavesEnabled: true,
+    analyticsEnabled: true,
+    analyticsTestMode: false,
+    gameVersion: '1.1.1',
+    buildType: 'production',
+    ...overrides
+  };
+}
+
+function createClient({ fetchImpl, config, storage, search = '', now, onConflict, timers = false } = {}) {
+  return new RegolithBackend({
+    config: config || baseConfig(),
+    storage: storage || new MemoryStorage(),
+    fetchImpl,
+    cryptoImpl: webcrypto,
+    locationImpl: { search },
+    navigatorImpl: { platform: 'TestOS', userAgent: 'Desktop Test' },
+    matchMediaImpl: () => ({ matches: false }),
+    now: now || (() => Date.parse('2026-08-13T12:00:00Z')),
+    setTimeoutImpl: timers ? setTimeout : () => 1,
+    clearTimeoutImpl: timers ? clearTimeout : () => {},
+    onConflict
+  });
+}
+
+function saveStore(local = null, meta = {}) {
+  return {
+    value: local,
+    metadata: { ...meta },
+    read() { return this.value; },
+    meta() { return { ...this.metadata }; },
+    replaceFromCloud(value, record) {
+      this.value = value;
+      this.metadata = { cloudVersion: record.version, cloudChecksum: record.checksum };
+    },
+    markCloudSynced(version, checksum) {
+      this.metadata.cloudVersion = version;
+      this.metadata.cloudChecksum = checksum;
+    }
+  };
+}
+
+async function settle() {
+  await new Promise(resolve => setImmediate(resolve));
+  await new Promise(resolve => setImmediate(resolve));
+}
+
+test('cloud saves hash decoded JSON bytes and round-trip safely', async () => {
+  const original = { missionIdx: 3, unlocked: ['memo'], text: 'lunar ✓' };
+  const encoded = await encodeCloudSave(original, webcrypto);
+  assert.match(encoded.payload, /^[A-Za-z0-9+/]+=*$/);
+  assert.match(encoded.checksum, /^[0-9a-f]{64}$/);
+  assert.deepEqual(await decodeCloudSave({ ...encoded }, webcrypto), original);
+});
+
+test('cloud save decoder rejects payload tampering', async () => {
+  const encoded = await encodeCloudSave({ missionIdx: 1 }, webcrypto);
+  const tampered = { ...encoded, payload: btoa('{"missionIdx":2}') };
+  await assert.rejects(() => decodeCloudSave(tampered, webcrypto), /checksum/i);
+});
+
+test('disabled backend performs no network work', async () => {
+  let calls = 0;
+  const client = createClient({ config: baseConfig({ enabled: false }), fetchImpl: async () => { calls++; } });
+  assert.deepEqual(await client.initialize(), { enabled: false });
+  assert.equal(calls, 0);
+});
+
+test('install creation is followed by validation and identifiers are persisted', async () => {
+  const calls = [];
+  const storage = new MemoryStorage();
+  const client = createClient({
+    storage,
+    fetchImpl: async (url, options) => {
+      calls.push({ url, options, body: options.body && JSON.parse(options.body) });
+      if (url === '/api/glitch/installs') return response({ data: { id: INSTALL_ID, user_id: 'user' } }, 201);
+      if (url.endsWith('/validate')) return response({ valid: true, user_id: 'user' });
+      throw new Error(`Unexpected ${url}`);
+    }
+  });
+  const result = await client.initialize();
+  assert.equal(result.installId, INSTALL_ID);
+  assert.equal(calls[0].url, '/api/glitch/installs');
+  assert.equal(calls[1].url, `/api/glitch/installs/${INSTALL_ID}/validate`);
+  assert.equal(calls[0].body.platform, 'web');
+  assert.equal(calls[0].body.game_version, '1.1.1');
+  assert.ok(calls[0].body.user_install_id);
+  assert.equal(storage.getItem('regolith.glitch.install_id.v1'), INSTALL_ID);
+});
+
+test('desktop launch install ID is validated before fallback creation', async () => {
+  const calls = [];
+  const client = createClient({
+    search: `?title_id=${TITLE_ID}&install_id=${INSTALL_ID}&user_install_id=device-7&session_id=session-9`,
+    fetchImpl: async (url) => { calls.push(url); return response({ valid: true, user_id: 'user' }); }
+  });
+  await client.initialize();
+  assert.deepEqual(calls, [`/api/glitch/installs/${INSTALL_ID}/validate`]);
+  assert.equal(client.userInstallId, 'device-7');
+  assert.equal(client.sessionId, 'session-9');
+});
+
+test('missing desktop install is recreated and revalidated', async () => {
+  const calls = [];
+  const client = createClient({
+    search: `?install_id=${INSTALL_ID}`,
+    fetchImpl: async (url) => {
+      calls.push(url);
+      if (calls.length === 1) return response({ code: 'INSTALL_NOT_FOUND' }, 404);
+      if (url === '/api/glitch/installs') return response({ data: { id: INSTALL_ID } }, 201);
+      return response({ valid: true });
+    }
+  });
+  await client.initialize();
+  assert.deepEqual(calls, [
+    `/api/glitch/installs/${INSTALL_ID}/validate`,
+    '/api/glitch/installs',
+    `/api/glitch/installs/${INSTALL_ID}/validate`
+  ]);
+});
+
+test('license denial produces a player-safe access error', async () => {
+  const client = createClient({
+    fetchImpl: async (url) => url === '/api/glitch/installs'
+      ? response({ data: { id: INSTALL_ID } }, 201)
+      : response({ valid: false, reason: 'TRIAL_EXPIRED' })
+  });
+  await assert.rejects(() => client.initialize(), (error) => {
+    assert.ok(error instanceof BackendAccessError);
+    assert.equal(error.reason, 'TRIAL_EXPIRED');
+    assert.doesNotMatch(error.playerMessage, /403|UUID|JSON|stack/i);
+    return true;
+  });
+});
+
+test('recent successful validation grants a bounded offline grace period', async () => {
+  const now = Date.parse('2026-08-13T12:00:00Z');
+  const storage = new MemoryStorage({
+    'regolith.glitch.install_id.v1': INSTALL_ID,
+    'regolith.glitch.last_valid_at.v1': String(now - 60_000)
+  });
+  const client = createClient({ storage, now: () => now, fetchImpl: async () => { throw new Error('offline'); } });
+  const result = await client.initialize();
+  assert.equal(result.offlineGrace, true);
+  assert.equal(client.online, false);
+});
+
+test('analytics requires production permission and explicit consent', async () => {
+  let eventCalls = 0;
+  const client = createClient({
+    config: baseConfig({ analyticsEnabled: false }),
+    fetchImpl: async (url) => {
+      if (url === '/api/glitch/installs') return response({ data: { id: INSTALL_ID } }, 201);
+      if (url.endsWith('/validate')) return response({ valid: true });
+      eventCalls++;
+      return response({ data: {} }, 201);
+    }
+  });
+  await client.initialize();
+  client.setAnalyticsConsent(true);
+  client.track('main_menu', 'viewed');
+  await settle();
+  assert.equal(eventCalls, 0);
+});
+
+test('analytics payloads contain stable context, remove sensitive keys, and deduplicate', async () => {
+  const events = [];
+  const client = createClient({
+    fetchImpl: async (url, options) => {
+      if (url === '/api/glitch/installs') return response({ data: { id: INSTALL_ID } }, 201);
+      if (url.endsWith('/validate')) return response({ valid: true });
+      events.push(JSON.parse(options.body));
+      return response({ data: { id: 'event' } }, 201);
+    }
+  });
+  await client.initialize();
+  client.setAnalyticsConsent(true);
+  await settle();
+  events.length = 0;
+  client.track('mission_01', 'objective_completed', {
+    objective_id: 'scan', password: 'never-send', private_message: 'secret'
+  }, { dedupeKey: 'objective-1' });
+  client.track('mission_01', 'objective_completed', { objective_id: 'scan' }, { dedupeKey: 'objective-1' });
+  await settle();
+  assert.equal(events.length, 1);
+  assert.equal(events[0].game_install_id, INSTALL_ID);
+  assert.equal(events[0].step_key, 'mission_01');
+  assert.equal(events[0].metadata.game_version, '1.1.1');
+  assert.equal(events[0].metadata.password, undefined);
+  assert.equal(events[0].metadata.private_message, undefined);
+});
+
+test('analytics provider failures never reject gameplay calls', async () => {
+  const client = createClient({
+    fetchImpl: async (url) => {
+      if (url === '/api/glitch/installs') return response({ data: { id: INSTALL_ID } }, 201);
+      if (url.endsWith('/validate')) return response({ valid: true });
+      throw new Error('blocked');
+    }
+  });
+  await client.initialize();
+  client.setAnalyticsConsent(true);
+  assert.doesNotThrow(() => client.track('gameplay', 'started'));
+  await settle();
+  assert.ok(client.eventQueue.length >= 1);
+});
+
+test('new local progress uploads with exact cloud-save fields', async () => {
+  const requests = [];
+  const local = { missionIdx: 2, relaysPlaced: 1, met: 45, anoms: [1, 0, 2] };
+  const store = saveStore(local);
+  const client = createClient({
+    fetchImpl: async (url, options = {}) => {
+      requests.push({ url, body: options.body && JSON.parse(options.body) });
+      if (url === '/api/glitch/installs') return response({ data: { id: INSTALL_ID, user_id: 'user' } }, 201);
+      if (url.endsWith('/validate')) return response({ valid: true, user_id: 'user' });
+      if (options.method === 'GET') return response({ data: [] });
+      if (url.endsWith('/saves')) return response({ data: { id: SAVE_ID, version: 1, checksum: requests.at(-1).body.checksum } }, 201);
+      if (url === '/api/glitch/events') return response({ data: {} }, 201);
+      throw new Error(`Unexpected ${url}`);
+    }
+  });
+  await client.initialize();
+  await client.syncInitialSave(store);
+  await settle();
+  const upload = requests.find(item => item.url.endsWith('/saves') && item.body?.payload);
+  assert.equal(upload.body.slot_index, 0);
+  assert.equal(upload.body.save_type, 'auto');
+  assert.equal(upload.body.base_version, 0);
+  assert.match(upload.body.checksum, /^[0-9a-f]{64}$/);
+  assert.deepEqual(JSON.parse(atob(upload.body.payload)), local);
+  assert.equal(store.metadata.cloudVersion, 1);
+});
+
+test('remote-only cloud progress is checksum-verified and restored locally', async () => {
+  const remoteData = { missionIdx: 3, met: 321, relaysPlaced: 2 };
+  const encoded = await encodeCloudSave(remoteData, webcrypto);
+  const store = saveStore(null);
+  const client = createClient({
+    fetchImpl: async (url, options = {}) => {
+      if (url === '/api/glitch/installs') return response({ data: { id: INSTALL_ID, user_id: 'user' } }, 201);
+      if (url.endsWith('/validate')) return response({ valid: true, user_id: 'user' });
+      if (options.method === 'GET') return response({ data: [{
+        id: SAVE_ID, slot_index: 0, version: 7, client_timestamp: '2026-08-13T11:00:00Z', ...encoded
+      }] });
+      if (url === '/api/glitch/events') return response({ data: {} }, 201);
+      throw new Error(`Unexpected ${url}`);
+    }
+  });
+  await client.initialize();
+  await client.syncInitialSave(store);
+  assert.deepEqual(store.value, remoteData);
+  assert.equal(store.metadata.cloudVersion, 7);
+  assert.equal(store.metadata.cloudChecksum, encoded.checksum);
+});
+
+test('409 cloud conflict is surfaced and resolved through the documented route', async () => {
+  const local = { missionIdx: 4, met: 500 };
+  const remoteEncoded = await encodeCloudSave({ missionIdx: 2, met: 200 }, webcrypto);
+  const store = saveStore(local);
+  const calls = [];
+  const client = createClient({
+    onConflict: async () => 'use_client',
+    fetchImpl: async (url, options = {}) => {
+      const body = options.body && JSON.parse(options.body);
+      calls.push({ url, body, method: options.method });
+      if (url === '/api/glitch/installs') return response({ data: { id: INSTALL_ID, user_id: 'user' } }, 201);
+      if (url.endsWith('/validate')) return response({ valid: true, user_id: 'user' });
+      if (options.method === 'GET') return response({ data: [{
+        id: SAVE_ID, slot_index: 0, version: 3, ...remoteEncoded
+      }] });
+      if (url.endsWith('/saves')) return response({
+        status: 'conflict', save_id: SAVE_ID, conflict_id: CONFLICT_ID,
+        server_version: 3, your_base_version: 0
+      }, 409);
+      if (url.endsWith(`/saves/${SAVE_ID}/resolve`)) return response({
+        data: { id: SAVE_ID, version: 4, checksum: body.choice === 'use_client' ? (await encodeCloudSave(local, webcrypto)).checksum : remoteEncoded.checksum }
+      });
+      if (url === '/api/glitch/events') return response({ data: {} }, 201);
+      throw new Error(`Unexpected ${url}`);
+    }
+  });
+  await client.initialize();
+  await client.syncInitialSave(store);
+  const resolveCall = calls.find(item => item.url.endsWith(`/saves/${SAVE_ID}/resolve`));
+  assert.deepEqual(resolveCall.body, { conflict_id: CONFLICT_ID, choice: 'use_client' });
+  assert.equal(store.metadata.cloudVersion, 4);
+});

--- a/test/backend-client.test.js
+++ b/test/backend-client.test.js
@@ -35,13 +35,13 @@ function baseConfig(overrides = {}) {
     apiOrigin: '',
     cloudSavesEnabled: true,
     analyticsEnabled: true,
-    gameVersion: '1.1.2',
+    gameVersion: '1.1.3',
     buildType: 'production',
     ...overrides
   };
 }
 
-function createClient({ fetchImpl, config, storage, search = '', now, onConflict, timers = false } = {}) {
+function createClient({ fetchImpl, config, storage, search = '', now, timers = false } = {}) {
   return new RegolithBackend({
     config: config || baseConfig(),
     storage: storage || new MemoryStorage(),
@@ -52,8 +52,7 @@ function createClient({ fetchImpl, config, storage, search = '', now, onConflict
     matchMediaImpl: () => ({ matches: false }),
     now: now || (() => Date.parse('2026-08-13T12:00:00Z')),
     setTimeoutImpl: timers ? setTimeout : () => 1,
-    clearTimeoutImpl: timers ? clearTimeout : () => {},
-    onConflict
+    clearTimeoutImpl: timers ? clearTimeout : () => {}
   });
 }
 
@@ -117,7 +116,7 @@ test('install creation is followed by validation and identifiers are persisted',
   assert.equal(calls[0].url, '/api/glitch/installs');
   assert.equal(calls[1].url, `/api/glitch/installs/${INSTALL_ID}/validate`);
   assert.equal(calls[0].body.platform, 'web');
-  assert.equal(calls[0].body.game_version, '1.1.2');
+  assert.equal(calls[0].body.game_version, '1.1.3');
   assert.ok(calls[0].body.user_install_id);
   assert.equal(storage.getItem('regolith.glitch.install_id.v1'), INSTALL_ID);
 });
@@ -219,7 +218,7 @@ test('analytics payloads contain stable context, remove sensitive keys, and dedu
   assert.equal(events.length, 1);
   assert.equal(events[0].game_install_id, INSTALL_ID);
   assert.equal(events[0].step_key, 'mission_01');
-  assert.equal(events[0].metadata.game_version, '1.1.2');
+  assert.equal(events[0].metadata.game_version, '1.1.3');
   assert.equal(events[0].metadata.password, undefined);
   assert.equal(events[0].metadata.private_message, undefined);
 });
@@ -287,13 +286,13 @@ test('remote-only cloud progress is checksum-verified and restored locally', asy
   assert.equal(store.metadata.cloudChecksum, encoded.checksum);
 });
 
-test('409 cloud conflict is surfaced and resolved through the documented route', async () => {
+test('initial divergent progress automatically restores the cloud copy', async () => {
   const local = { missionIdx: 4, met: 500 };
-  const remoteEncoded = await encodeCloudSave({ missionIdx: 2, met: 200 }, webcrypto);
+  const remote = { missionIdx: 2, met: 200 };
+  const remoteEncoded = await encodeCloudSave(remote, webcrypto);
   const store = saveStore(local);
   const calls = [];
   const client = createClient({
-    onConflict: async () => 'use_client',
     fetchImpl: async (url, options = {}) => {
       const body = options.body && JSON.parse(options.body);
       calls.push({ url, body, method: options.method });
@@ -302,20 +301,94 @@ test('409 cloud conflict is surfaced and resolved through the documented route',
       if (options.method === 'GET') return response({ data: [{
         id: SAVE_ID, slot_index: 0, version: 3, ...remoteEncoded
       }] });
-      if (url.endsWith('/saves')) return response({
-        status: 'conflict', save_id: SAVE_ID, conflict_id: CONFLICT_ID,
-        server_version: 3, your_base_version: 0
-      }, 409);
-      if (url.endsWith(`/saves/${SAVE_ID}/resolve`)) return response({
-        data: { id: SAVE_ID, version: 4, checksum: body.choice === 'use_client' ? (await encodeCloudSave(local, webcrypto)).checksum : remoteEncoded.checksum }
-      });
       if (url === '/api/glitch/events') return response({ data: {} }, 201);
       throw new Error(`Unexpected ${url}`);
     }
   });
   await client.initialize();
   await client.syncInitialSave(store);
+  assert.deepEqual(store.value, remote);
+  assert.equal(store.metadata.cloudVersion, 3);
+  assert.equal(calls.some(item => item.url.endsWith('/saves') && item.method === 'POST'), false);
+  assert.equal(calls.some(item => item.url.includes('/resolve')), false);
+});
+
+test('409 cloud conflict automatically keeps and restores the cloud copy', async () => {
+  const local = { missionIdx: 4, met: 500 };
+  const baseCloud = { missionIdx: 2, met: 200 };
+  const winningCloud = { missionIdx: 3, met: 350 };
+  const baseEncoded = await encodeCloudSave(baseCloud, webcrypto);
+  const winningEncoded = await encodeCloudSave(winningCloud, webcrypto);
+  const store = saveStore(local, { cloudVersion: 3, cloudChecksum: baseEncoded.checksum });
+  const calls = [];
+  let resolved = false;
+  const client = createClient({
+    fetchImpl: async (url, options = {}) => {
+      const body = options.body && JSON.parse(options.body);
+      calls.push({ url, body, method: options.method });
+      if (url === '/api/glitch/installs') return response({ data: { id: INSTALL_ID, user_id: 'user' } }, 201);
+      if (url.endsWith('/validate')) return response({ valid: true, user_id: 'user' });
+      if (options.method === 'GET') return response({ data: [{
+        id: SAVE_ID, slot_index: 0, version: resolved ? 4 : 3,
+        ...(resolved ? winningEncoded : baseEncoded)
+      }] });
+      if (url.endsWith('/saves')) return response({
+        status: 'conflict', save_id: SAVE_ID, conflict_id: CONFLICT_ID,
+        server_version: 4, your_base_version: 3
+      }, 409);
+      if (url.endsWith(`/saves/${SAVE_ID}/resolve`)) {
+        resolved = true;
+        return response({ data: { id: SAVE_ID, version: 4, checksum: winningEncoded.checksum } });
+      }
+      if (url === '/api/glitch/events') return response({ data: {} }, 201);
+      throw new Error(`Unexpected ${url}`);
+    }
+  });
+  await client.initialize();
+  await client.syncInitialSave(store);
+  for (let attempt = 0; attempt < 10 && client.cloudSending; attempt++) await settle();
   const resolveCall = calls.find(item => item.url.endsWith(`/saves/${SAVE_ID}/resolve`));
-  assert.deepEqual(resolveCall.body, { conflict_id: CONFLICT_ID, choice: 'use_client' });
+  assert.deepEqual(resolveCall.body, { conflict_id: CONFLICT_ID, choice: 'keep_server' });
+  assert.deepEqual(store.value, winningCloud);
   assert.equal(store.metadata.cloudVersion, 4);
+  assert.equal(store.metadata.cloudChecksum, winningEncoded.checksum);
+});
+
+test('resolved cloud conflict never retries stale local data when restore is unavailable', async () => {
+  const local = { missionIdx: 4, met: 500 };
+  const baseEncoded = await encodeCloudSave({ missionIdx: 2, met: 200 }, webcrypto);
+  const store = saveStore(local, { cloudVersion: 3, cloudChecksum: baseEncoded.checksum });
+  const calls = [];
+  let resolved = false;
+  const client = createClient({
+    fetchImpl: async (url, options = {}) => {
+      const body = options.body && JSON.parse(options.body);
+      calls.push({ url, body, method: options.method });
+      if (url === '/api/glitch/installs') return response({ data: { id: INSTALL_ID, user_id: 'user' } }, 201);
+      if (url.endsWith('/validate')) return response({ valid: true, user_id: 'user' });
+      if (options.method === 'GET' && !resolved) return response({ data: [{
+        id: SAVE_ID, slot_index: 0, version: 3, ...baseEncoded
+      }] });
+      if (options.method === 'GET' && resolved) throw new Error('temporary read failure');
+      if (url.endsWith('/saves')) return response({
+        status: 'conflict', save_id: SAVE_ID, conflict_id: CONFLICT_ID,
+        server_version: 4, your_base_version: 3
+      }, 409);
+      if (url.endsWith(`/saves/${SAVE_ID}/resolve`)) {
+        resolved = true;
+        return response({ data: { id: SAVE_ID, version: 4, checksum: baseEncoded.checksum } });
+      }
+      if (url === '/api/glitch/events') return response({ data: {} }, 201);
+      throw new Error(`Unexpected ${url}`);
+    }
+  });
+  await client.initialize();
+  await client.syncInitialSave(store);
+  for (let attempt = 0; attempt < 10 && client.cloudSending; attempt++) await settle();
+  const resolveCall = calls.find(item => item.url.endsWith(`/saves/${SAVE_ID}/resolve`));
+  assert.deepEqual(resolveCall.body, { conflict_id: CONFLICT_ID, choice: 'keep_server' });
+  assert.equal(client.cloudDisabled, true);
+  assert.equal(client.cloudPending, null);
+  assert.deepEqual(store.value, local);
+  assert.equal(calls.filter(item => item.url.endsWith('/saves') && item.method === 'POST').length, 1);
 });

--- a/test/glitch-proxy.test.js
+++ b/test/glitch-proxy.test.js
@@ -136,15 +136,19 @@ test('checksum mismatch is rejected without contacting Glitch', async () => {
   assert.equal(upstreamCalls, 0);
 });
 
-test('behavior analytics route is unavailable outside production unless test mode is explicit', async () => {
-  await withServer({ env: enabledEnv({ NODE_ENV: 'development' }), fetchImpl: async () => upstreamJson({}) }, async (base) => {
+test('behavior analytics remains enabled outside production when Glitch is enabled', async () => {
+  let upstreamCalls = 0;
+  await withServer({
+    env: enabledEnv({ NODE_ENV: 'development' }),
+    fetchImpl: async () => { upstreamCalls++; return upstreamJson({ data: { id: 'event' } }, 201); }
+  }, async (base) => {
     const response = await fetch(`${base}/api/glitch/events`, {
       method: 'POST', headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ game_install_id: INSTALL_ID, step_key: 'main_menu', action_key: 'viewed' })
     });
-    assert.equal(response.status, 404);
-    assert.equal((await response.json()).code, 'ANALYTICS_DISABLED');
+    assert.equal(response.status, 201);
   });
+  assert.equal(upstreamCalls, 1);
 });
 
 test('behavior events forward only documented fields in production', async () => {

--- a/test/glitch-proxy.test.js
+++ b/test/glitch-proxy.test.js
@@ -1,0 +1,185 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { createHash } from 'node:crypto';
+import { once } from 'node:events';
+import { createRegolithServer } from '../server.js';
+
+const INSTALL_ID = '11111111-1111-4111-8111-111111111111';
+const TOKEN = 'test-runtime-token-that-must-never-be-public';
+
+function enabledEnv(overrides = {}) {
+  return {
+    GLITCH_BACKEND_ENABLED: '1',
+    GLITCH_TITLE_TOKEN: TOKEN,
+    NODE_ENV: 'production',
+    ...overrides
+  };
+}
+
+async function withServer(options, fn) {
+  const { server, config } = createRegolithServer(options);
+  server.listen(0, '127.0.0.1');
+  await once(server, 'listening');
+  const { port } = server.address();
+  try { await fn(`http://127.0.0.1:${port}`, config); }
+  finally { await new Promise(resolve => server.close(resolve)); }
+}
+
+function upstreamJson(body, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' }
+  });
+}
+
+test('static runtime configuration is disabled without credentials', async () => {
+  await withServer({ env: {} }, async (base) => {
+    const response = await fetch(`${base}/runtime-config.js`);
+    const text = await response.text();
+    assert.equal(response.status, 200);
+    assert.match(text, /"enabled":false/);
+    assert.doesNotMatch(text, /Bearer|gl_deploy|title-token/i);
+  });
+});
+
+test('enabled runtime configuration exposes capability flags but never the token', async () => {
+  await withServer({ env: enabledEnv() }, async (base) => {
+    const text = await (await fetch(`${base}/runtime-config.js`)).text();
+    assert.match(text, /"enabled":true/);
+    assert.match(text, /"analyticsEnabled":true/);
+    assert.doesNotMatch(text, new RegExp(TOKEN));
+  });
+});
+
+test('server-only files and traversal attempts are not publicly readable', async () => {
+  await withServer({ env: enabledEnv() }, async (base) => {
+    assert.equal((await fetch(`${base}/backend/runtime-secrets.json`)).status, 404);
+    assert.equal((await fetch(`${base}/src/../../server.js`)).status, 404);
+    assert.equal((await fetch(`${base}/package.json`)).status, 404);
+  });
+});
+
+test('install proxy uses the exact Glitch route, bearer token, and allowlisted fields', async () => {
+  const upstreamCalls = [];
+  await withServer({
+    env: enabledEnv(),
+    fetchImpl: async (url, options) => {
+      upstreamCalls.push({ url, options, body: JSON.parse(options.body) });
+      return upstreamJson({ data: { id: INSTALL_ID } }, 201);
+    }
+  }, async (base) => {
+    const response = await fetch(`${base}/api/glitch/installs`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ user_install_id: 'stable-device', platform: 'web', invented_field: 'drop-me' })
+    });
+    assert.equal(response.status, 201);
+  });
+  assert.equal(upstreamCalls[0].url,
+    'https://api.glitch.fun/api/titles/6bd2c447-1770-441b-b94b-bceed5e81e87/installs');
+  assert.equal(upstreamCalls[0].options.headers.Authorization, `Bearer ${TOKEN}`);
+  assert.equal(upstreamCalls[0].body.invented_field, undefined);
+});
+
+test('install validation rejects non-UUID path values before upstream', async () => {
+  let upstreamCalls = 0;
+  await withServer({ env: enabledEnv(), fetchImpl: async () => { upstreamCalls++; } }, async (base) => {
+    const response = await fetch(`${base}/api/glitch/installs/not-a-uuid/validate`, {
+      method: 'POST', headers: { 'Content-Type': 'application/json' }, body: '{}'
+    });
+    assert.equal(response.status, 422);
+    assert.equal((await response.json()).code, 'VALIDATION_ERROR');
+  });
+  assert.equal(upstreamCalls, 0);
+});
+
+test('save proxy verifies SHA-256 over decoded bytes before forwarding', async () => {
+  const raw = Buffer.from(JSON.stringify({ missionIdx: 2 }));
+  const payload = raw.toString('base64');
+  const checksum = createHash('sha256').update(raw).digest('hex');
+  let forwarded;
+  await withServer({
+    env: enabledEnv(),
+    fetchImpl: async (url, options) => {
+      forwarded = { url, body: JSON.parse(options.body) };
+      return upstreamJson({ data: { version: 1, checksum } }, 201);
+    }
+  }, async (base) => {
+    const response = await fetch(`${base}/api/glitch/installs/${INSTALL_ID}/saves`, {
+      method: 'POST', headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        slot_index: 0, payload, checksum, save_type: 'auto',
+        client_timestamp: '2026-08-13T12:00:00.000Z', base_version: 0
+      })
+    });
+    assert.equal(response.status, 201);
+  });
+  assert.equal(forwarded.url,
+    `https://api.glitch.fun/api/titles/6bd2c447-1770-441b-b94b-bceed5e81e87/installs/${INSTALL_ID}/saves`);
+  assert.equal(forwarded.body.checksum, checksum);
+});
+
+test('checksum mismatch is rejected without contacting Glitch', async () => {
+  const raw = Buffer.from('{}');
+  let upstreamCalls = 0;
+  await withServer({ env: enabledEnv(), fetchImpl: async () => { upstreamCalls++; } }, async (base) => {
+    const response = await fetch(`${base}/api/glitch/installs/${INSTALL_ID}/saves`, {
+      method: 'POST', headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        slot_index: 0, payload: raw.toString('base64'), checksum: '0'.repeat(64),
+        save_type: 'auto', client_timestamp: '2026-08-13T12:00:00.000Z'
+      })
+    });
+    assert.equal(response.status, 400);
+    assert.equal((await response.json()).code, 'CHECKSUM_MISMATCH');
+  });
+  assert.equal(upstreamCalls, 0);
+});
+
+test('behavior analytics route is unavailable outside production unless test mode is explicit', async () => {
+  await withServer({ env: enabledEnv({ NODE_ENV: 'development' }), fetchImpl: async () => upstreamJson({}) }, async (base) => {
+    const response = await fetch(`${base}/api/glitch/events`, {
+      method: 'POST', headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ game_install_id: INSTALL_ID, step_key: 'main_menu', action_key: 'viewed' })
+    });
+    assert.equal(response.status, 404);
+    assert.equal((await response.json()).code, 'ANALYTICS_DISABLED');
+  });
+});
+
+test('behavior events forward only documented fields in production', async () => {
+  let forwarded;
+  await withServer({
+    env: enabledEnv(),
+    fetchImpl: async (url, options) => {
+      forwarded = { url, body: JSON.parse(options.body) };
+      return upstreamJson({ data: { id: 'event' } }, 201);
+    }
+  }, async (base) => {
+    const response = await fetch(`${base}/api/glitch/events`, {
+      method: 'POST', headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        game_install_id: INSTALL_ID, step_key: 'mission_01', action_key: 'started',
+        metadata: { input_method: 'keyboard_mouse' }, private_token: 'drop-me'
+      })
+    });
+    assert.equal(response.status, 201);
+  });
+  assert.equal(forwarded.url,
+    'https://api.glitch.fun/api/titles/6bd2c447-1770-441b-b94b-bceed5e81e87/events');
+  assert.equal(forwarded.body.private_token, undefined);
+});
+
+test('cross-origin API writes are rejected unless explicitly allowlisted', async () => {
+  let upstreamCalls = 0;
+  await withServer({ env: enabledEnv(), fetchImpl: async () => { upstreamCalls++; } }, async (base) => {
+    const response = await fetch(`${base}/api/glitch/installs`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', Origin: 'https://attacker.example' },
+      body: JSON.stringify({ user_install_id: 'stable-device' })
+    });
+    assert.equal(response.status, 403);
+    assert.equal((await response.json()).code, 'ORIGIN_NOT_ALLOWED');
+  });
+  assert.equal(upstreamCalls, 0);
+});


### PR DESCRIPTION
## Summary

- add an optional Node proxy for Glitch install creation and validation while preserving the normal static build
- add local-first cloud saves with SHA-256 integrity and automatic cloud-authoritative conflict resolution
- remove the cloud-versus-device choice: ambiguous divergence and 409 conflicts automatically keep, download, verify, and restore the Glitch cloud copy
- prevent stale local data from being retried if the cloud winner cannot be downloaded after resolution
- add privacy-filtered Glitch behavior analytics and retention heartbeats that start automatically whenever the Glitch backend is enabled
- add secure runtime configuration, Docker deployment support, and a no-secret deployment script
- document architecture, privacy, configuration, limitations, extension rules, and the resolved Glitch public-play incident

## Security

- runtime and deploy credentials are excluded from Git and browser assets
- only allowlisted Glitch routes and fields can be proxied
- server-only files and path traversal are blocked
- cloud payloads are checksum-verified before replacing local progress
- analytics removes tokens, passwords, email, private/player-entered text, raw exceptions, stack traces, and precise location

## Verification

- `npm test` — 26 tests passing
- syntax checks for server, proxy, client integration, game bootstrap, and deployment script
- production Glitch build 1.1.3 (`019ff9e2-aafa-70c1-8402-c5d7ca46513b`) is ready and active
- Azure revision `regolith-node--0000003` is healthy with two replicas and 100% traffic
- production runtime configuration reports 1.1.3 with cloud saves and analytics enabled
- production HTML and rendered game contain no cloud-versus-device choice
- authenticated Glitch launch created a visible Node iframe without Aegis/GPU startup or a launch error
- the deployed game reached its main menu; install validation returned HTTP 200 and behavior events returned HTTP 201
- guest Cloud Save still returns the documented `GUEST_NOT_ALLOWED`

## Resolved platform incident

The stale-title/Aegis routing outage remains resolved. Full original evidence and resolution verification are in `docs/GLITCH_PLAY_INCIDENT_2026-08-13.md`. The title still reports `is_live: false`, `approval_status: 0`, and no distribution-fee access, so anonymous/non-developer publication remains a separate policy check.
